### PR TITLE
add a skycofl trade overlay with valuation, lowball coins, and dev tools

### DIFF
--- a/src/client/java/com/coflnet/CoflModClient.java
+++ b/src/client/java/com/coflnet/CoflModClient.java
@@ -148,6 +148,14 @@ public class CoflModClient implements ClientModInitializer {
     public static CoflModClient instance;
     public static SignBlockEntity sign = null;
     public static String pendingBazaarSearch = null;
+    // Trade coins input: when set, the next sign editor that opens (from clicking
+    // the trade Coins-transaction slot) is auto-filled with this value, mirroring
+    // the bazaar-search auto-fill flow. Format is a plain digit string.
+    public static volatile String pendingCoinAmount = null;
+    // Trade partner full name captured from chat. Hypixel truncates the name in
+    // the trade window title (e.g. "VerticleFr"), but the trade-request chat line
+    // carries the FULL name. TradeGUI prefers this over the truncated title.
+    public static volatile String lastTradePartner = null;
     public static boolean flipperChatOnlyMode = false;
     
     // Scoreboard dirty flag - set by ScoreboardMixin when packets arrive
@@ -389,6 +397,45 @@ public class CoflModClient implements ClientModInitializer {
             );
         });
 
+        // Dev mode: inject a "Copy Dump" button into any container screen so the
+        // open container's signature can be copied to the clipboard (you cannot
+        // type chat commands while a container GUI has focus). Only added when
+        // dev mode is enabled via /cofl dev on.
+        ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+            if (!com.coflnet.config.DevManager.isEnabled()) {
+                return;
+            }
+            if (!(screen instanceof ContainerScreen)) {
+                return;
+            }
+            net.minecraft.client.gui.components.Button dumpButton =
+                    net.minecraft.client.gui.components.Button.builder(
+                            Component.literal("Copy Dump"),
+                            btn -> copyOpenContainerDumpToClipboard()
+                    ).bounds(2, 2, 80, 16).build();
+            net.fabricmc.fabric.api.client.screen.v1.Screens.getWidgets(screen).add(dumpButton);
+        });
+
+        // Trade pricing: when a Hypixel trade window opens, trigger the existing
+        // description/price pipeline for its items so worth data is available.
+        // The trade title is not in the SKYBLOCK_MENU allowlist that
+        // loadDescriptionsForInv gates on, so we trigger the price load directly.
+        ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
+            if (screen instanceof ContainerScreen cs && isTradeScreenByTitle(cs)) {
+                NonNullList<ItemStack> items = cs.getMenu().getItems();
+                loadDescriptionsForItems(cs.getTitle().getString(), items);
+
+                // Replace the trade window with the SkyCofl TradeGUI overlay ONLY
+                // when the trade overlay is enabled (/cofl tradegui on). Dev mode
+                // deliberately does NOT trigger the swap, so /cofl dev on leaves the
+                // normal Hypixel trade window up WITH the Copy Dump button for testing.
+                if (com.coflnet.config.TradeGuiManager.isEnabled()
+                        && !(client.gui.screen() instanceof com.coflnet.gui.trade.TradeGUI)) {
+                    client.gui.setScreen(new com.coflnet.gui.trade.TradeGUI(cs));
+                }
+            }
+        });
+
         // General screen event to check for account switches in menus
         ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
             // Only check for account switches when not connected to a server
@@ -513,6 +560,9 @@ public class CoflModClient implements ClientModInitializer {
 
         ClientReceiveMessageEvents.ALLOW_GAME.register((message, overlay) -> {
             String messageText = message.getString();
+            // Capture the full trade-partner name from trade-request chat lines
+            // (Hypixel truncates it in the trade window title).
+            captureTradePartner(messageText);
             // Skip backend processing for our own display messages to avoid a feedback loop.
             if (!messageText.startsWith(TEXT_TUNNELS_MESSAGE_PREFIX)) {
                 EventRegistry.onChatMessage(messageText);
@@ -670,6 +720,323 @@ public class CoflModClient implements ClientModInitializer {
         return render + "s";
     }
 
+    // ===== Hypixel trade window (confirmed via dev Copy Dump) =====
+    // 45-slot ContainerScreen, title starts with "You", divider column (index 4)
+    // is gray_stained_glass_pane named "⇦ Your stuff".
+    public static final int[] TRADE_YOUR_SLOTS  = {0,1,2,3, 9,10,11,12, 18,19,20,21, 27,28,29,30};
+    public static final int[] TRADE_THEIR_SLOTS = {5,6,7,8, 14,15,16,17, 23,24,25,26, 32,33,34,35};
+    private static final int[] TRADE_DIVIDER_SLOTS = {4,13,22,31,40};
+
+    /**
+     * Detects the Hypixel trade window. Multi-signal gate: 45-slot container,
+     * title starts with "You", and the center divider column is glass panes.
+     */
+    public static boolean isTradeScreen(ContainerScreen cs) {
+        net.minecraft.world.Container container = cs.getMenu().getContainer();
+        if (container.getContainerSize() != 45) {
+            return false;
+        }
+        if (!cs.getTitle().getString().startsWith("You")) {
+            return false;
+        }
+        for (int slot : TRADE_DIVIDER_SLOTS) {
+            ItemStack pane = container.getItem(slot);
+            if (pane.isEmpty()) {
+                return false;
+            }
+            String key = net.minecraft.core.registries.BuiltInRegistries.ITEM
+                    .getKey(pane.getItem()).getPath();
+            if (!key.contains("glass_pane")) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Lightweight trade gate for the overlay swap: 45-slot container whose title
+     * starts with "You". Unlike {@link #isTradeScreen}, this does NOT require the
+     * divider glass panes (Hypixel sends those a few ticks after the screen opens),
+     * so the swap can fire on the very first init instead of lagging.
+     */
+    public static boolean isTradeScreenByTitle(ContainerScreen cs) {
+        return cs.getMenu().getContainer().getContainerSize() == 45
+                && cs.getTitle().getString().startsWith("You");
+    }
+    /** Worth basis selectable by the user (median vs lowest BIN). */
+    public enum WorthBasis { LBIN, MEDIAN }
+
+    /**
+     * Extracts a PER-ITEM coin worth from the backend tooltip lines.
+     * <p>
+     * AH items: LBIN reads the "lbin:" line, MEDIAN the "Med:" line (both
+     * per-item). Bazaar items use a "Buy: X (N each)Sell: Y (M each)" line —
+     * LBIN maps to Buy's per-unit "each" value, MEDIAN to Sell's. The per-item
+     * value is what callers multiply by stack count. Returns null if neither a
+     * matching AH nor bazaar line is present (truly unpriced).
+     */
+    public static Long parseWorthFromTips(DescriptionHandler.DescModification[] tips, WorthBasis basis) {
+        if (tips == null) {
+            return null;
+        }
+        String prefix = (basis == WorthBasis.LBIN) ? "lbin:" : "med:";
+        Long bazaar = null;
+        for (DescriptionHandler.DescModification t : tips) {
+            if (t == null || t.value == null) {
+                continue;
+            }
+            String plain = ChatFormatting.stripFormatting(t.value);
+            if (plain == null) {
+                continue;
+            }
+            plain = plain.trim();
+            String lower = plain.toLowerCase(Locale.ROOT);
+            // AH line (preferred when present).
+            if (lower.startsWith(prefix)) {
+                Long v = extractFirstNumber(plain);
+                if (v != null) {
+                    return v;
+                }
+            }
+            // Bazaar line: "Buy: 37.49K (585.8 each)Sell: 33.38K (521.6 each)".
+            if (bazaar == null && (lower.contains("buy:") && lower.contains("each"))) {
+                bazaar = parseBazaarEach(plain, basis == WorthBasis.LBIN ? "buy" : "sell");
+            }
+        }
+        return bazaar; // null if no AH line matched and no bazaar line present
+    }
+
+    /**
+     * From a bazaar tip line, returns the per-unit "(N each)" value following
+     * the given side ("buy" or "sell"). Handles k/m/b suffixes and decimals.
+     */
+    private static Long parseBazaarEach(String plain, String side) {
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile(side + ":.*?\\(([\\d,.]+\\s*[kmb]?)\\s*each\\)", java.util.regex.Pattern.CASE_INSENSITIVE)
+                .matcher(plain);
+        if (m.find()) {
+            return parseCoinNumber(m.group(1));
+        }
+        return null;
+    }
+
+    /** First comma-grouped integer in a string (e.g. "lbin: ~901,098,980 ..." -> 901098980). */
+    private static Long extractFirstNumber(String s) {
+        java.util.regex.Matcher m = java.util.regex.Pattern.compile("(\\d[\\d,]*)").matcher(s);
+        if (m.find()) {
+            try {
+                return Long.parseLong(m.group(1).replace(",", ""));
+            } catch (NumberFormatException e) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Captures the full trade-partner IGN from Hypixel trade-request chat lines,
+     * which carry the un-truncated name (the trade window title shortens it):
+     *   "You have sent a trade request to NAME."
+     *   "NAME has sent you a trade request. Click here to accept!"
+     */
+    public static void captureTradePartner(String message) {
+        if (message == null) {
+            return;
+        }
+        String plain = ChatFormatting.stripFormatting(message).trim();
+        java.util.regex.Matcher sent = java.util.regex.Pattern
+                .compile("You have sent a trade request to ([A-Za-z0-9_]{1,16})")
+                .matcher(plain);
+        if (sent.find()) {
+            lastTradePartner = sent.group(1);
+            return;
+        }
+        java.util.regex.Matcher recv = java.util.regex.Pattern
+                .compile("([A-Za-z0-9_]{1,16}) has sent you a trade request")
+                .matcher(plain);
+        if (recv.find()) {
+            lastTradePartner = recv.group(1);
+        }
+    }
+
+    /**
+     * If the stack is an offered-coins player head, returns the amount, else null.
+     * Hypixel renders the offered amount either in full ("67 coins", "1,234 coins")
+     * OR abbreviated with a k/m/b suffix ("200k coins", "1.5m coins") — both must
+     * be parsed or coin offers show as 0 value.
+     */
+    public static Long parseCoinStack(ItemStack stack) {
+        if (stack == null || stack.isEmpty()) {
+            return null;
+        }
+        String plain = ChatFormatting.stripFormatting(stack.getHoverName().getString());
+        if (plain == null) {
+            return null;
+        }
+        plain = plain.trim();
+        // Capture the leading number (with optional commas, decimal, and k/m/b suffix)
+        // followed by the word "coins".
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("^([\\d,]*\\.?\\d+\\s*[kmb]?)\\s+coins$", java.util.regex.Pattern.CASE_INSENSITIVE)
+                .matcher(plain);
+        if (m.matches()) {
+            return parseCoinNumber(m.group(1));
+        }
+        return null;
+    }
+
+    /** Parses a coin amount token like "200k", "1.5m", "1,234", "67". */
+    private static Long parseCoinNumber(String token) {
+        if (token == null) {
+            return null;
+        }
+        String in = token.toLowerCase(Locale.ROOT).replace(",", "").replace(" ", "").trim();
+        if (in.isEmpty()) {
+            return null;
+        }
+        try {
+            char last = in.charAt(in.length() - 1);
+            double mult = 1.0;
+            if (last == 'k') {
+                mult = 1_000.0;
+                in = in.substring(0, in.length() - 1);
+            } else if (last == 'm') {
+                mult = 1_000_000.0;
+                in = in.substring(0, in.length() - 1);
+            } else if (last == 'b') {
+                mult = 1_000_000_000.0;
+                in = in.substring(0, in.length() - 1);
+            }
+            return (long) (Double.parseDouble(in) * mult);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Sums the worth of one trade side. Offered coins count at face value;
+     * other items are priced via their backend worth line (× stack count).
+     * @return [totalWorth, unpricedItemCount]
+     */
+    public static long[] valuateTradeSide(net.minecraft.world.Container container, int[] slots, WorthBasis basis) {
+        long total = 0;
+        long unpriced = 0;
+        for (int slot : slots) {
+            ItemStack stack = container.getItem(slot);
+            if (stack.isEmpty() || stack.getItem() == Items.AIR) {
+                continue;
+            }
+            Long coins = parseCoinStack(stack);
+            if (coins != null) {
+                total += coins;
+                continue;
+            }
+            String id = getIdFromStack(stack);
+            Long worth = parseWorthFromTips(DescriptionHandler.getTooltipData(id), basis);
+            if (worth != null) {
+                total += worth * stack.getCount();
+            } else {
+                unpriced++;
+            }
+        }
+        return new long[]{total, unpriced};
+    }
+
+    /**
+     * Step C diagnostic: computes and logs each side's total worth (both bases)
+     * plus the net difference. Triggered from the Copy Dump button on a trade
+     * screen, so prices have had time to load. No overlay yet.
+     */
+    private static void logTradeValuation(ContainerScreen cs) {
+        net.minecraft.world.Container container = cs.getMenu().getContainer();
+        sendChatMessage("§6§l=== Trade Valuation ===");
+        for (WorthBasis basis : WorthBasis.values()) {
+            long[] you = valuateTradeSide(container, TRADE_YOUR_SLOTS, basis);
+            long[] them = valuateTradeSide(container, TRADE_THEIR_SLOTS, basis);
+            long net = them[0] - you[0]; // positive => you come out ahead
+            String netStr = (net >= 0)
+                    ? "§a+" + formatCoins(net) + " (you gain)"
+                    : "§c-" + formatCoins(-net) + " (you lose)";
+            String label = (basis == WorthBasis.LBIN) ? "LBIN " : "Med  ";
+            sendChatMessage("§e" + label + "§7YOU §f" + formatCoins(you[0])
+                    + " §7| THEY §f" + formatCoins(them[0])
+                    + " §7| NET " + netStr
+                    + ((you[1] + them[1] > 0) ? " §8(" + (you[1] + them[1]) + " unpriced)" : ""));
+        }
+    }
+
+    /**
+     * Dev-mode diagnostic: builds a text dump of the currently open container
+     * screen (title, container size, and every non-empty slot with index,
+     * display name, count, and whether it is a glass pane) and copies it to the
+     * system clipboard. Triggered by the "Copy Dump" button shown in container
+     * screens while dev mode is on. Reads only; sends no packets.
+     */
+    private static void copyOpenContainerDumpToClipboard() {
+        Minecraft client = Minecraft.getInstance();
+        Screen screen = client.gui.screen();
+        if (!(screen instanceof ContainerScreen acs)) {
+            sendChatMessage("§c[dump] No container screen is open.");
+            return;
+        }
+
+        net.minecraft.world.Container container = acs.getMenu().getContainer();
+        int size = container.getContainerSize();
+        boolean trade = isTradeScreen(acs);
+        StringBuilder sb = new StringBuilder();
+        sb.append("title=\"").append(acs.getTitle().getString()).append("\"\n");
+        sb.append("containerSize=").append(size).append("\n");
+        sb.append("screenClass=").append(screen.getClass().getName()).append("\n");
+        sb.append("isTradeScreen=").append(trade).append("\n");
+
+        int shown = 0;
+        for (int i = 0; i < size; i++) {
+            ItemStack stack = container.getItem(i);
+            if (stack.isEmpty() || stack.getItem() == Items.AIR) {
+                continue;
+            }
+            String itemKey = net.minecraft.core.registries.BuiltInRegistries.ITEM
+                    .getKey(stack.getItem()).getPath();
+            boolean isPane = itemKey.contains("glass_pane");
+            sb.append("slot ").append(i)
+                    .append(" x").append(stack.getCount())
+                    .append(isPane ? " [PANE]" : "")
+                    .append(" \"").append(stack.getHoverName().getString()).append("\"")
+                    .append(" (").append(itemKey).append(")")
+                    .append("\n");
+            // Dev diagnostic: include the computed item id and any backend
+            // tooltip (DescModification) lines so we can see the exact worth
+            // line wording (median / lowest BIN) the parser must read.
+            if (!isPane) {
+                String id = getIdFromStack(stack);
+                sb.append("    id=").append(id).append("\n");
+                DescriptionHandler.DescModification[] tips = DescriptionHandler.getTooltipData(id);
+                if (tips == null) {
+                    sb.append("    tips=<none>\n");
+                } else {
+                    for (DescriptionHandler.DescModification t : tips) {
+                        sb.append("    tip ").append(t.type)
+                                .append("|line=").append(t.line)
+                                .append("|value=\"").append(t.value).append("\"\n");
+                    }
+                }
+            }
+            shown++;
+        }
+        sb.append("non-empty slots: ").append(shown).append("\n");
+
+        String dump = sb.toString();
+        client.keyboardHandler.setClipboard(dump);
+        sendChatMessage("§a[dump] Copied container dump to clipboard §7(" + shown
+                + " items, size " + size + (trade ? ", TRADE" : "") + ")");
+        System.out.println("[CoflModClient] container dump:\n" + dump);
+
+        // Step C diagnostic: if this is a trade, also log the per-side valuation.
+        if (trade) {
+            logTradeValuation(acs);
+        }
+    }
+
     private void registerDefaultCommands(CommandDispatcher<FabricClientCommandSource> dispatcher, String name) {
         dispatcher.register(ClientCommands.literal(name)
                 .executes(context -> {
@@ -771,6 +1138,36 @@ public class CoflModClient implements ClientModInitializer {
                 .executes(context -> {
                     String[] args = context.getArgument("args", String.class).split(" ");
                     
+                    // Toggle developer mode (shows the Copy Dump button in containers)
+                    if (args.length >= 1 && args[0].equalsIgnoreCase("dev")) {
+                        if (args.length >= 2 && (args[1].equalsIgnoreCase("on") || args[1].equalsIgnoreCase("off"))) {
+                            boolean enabled = args[1].equalsIgnoreCase("on");
+                            com.coflnet.config.DevManager.setEnabled(enabled);
+                            sendChatMessage("§aDeveloper mode " + (enabled ? "§aenabled" : "§cdisabled")
+                                    + "§7. Open any container to " + (enabled ? "see" : "hide") + " the §eCopy Dump §7button.");
+                        } else {
+                            boolean current = com.coflnet.config.DevManager.isEnabled();
+                            sendChatMessage("§7Developer mode is currently " + (current ? "§aon" : "§coff"));
+                            sendChatMessage("§7Usage: §e/cofl dev <on/off>");
+                        }
+                        return 1;
+                    }
+
+                    // Toggle the trade overlay (replaces the Hypixel trade window)
+                    if (args.length >= 1 && args[0].equalsIgnoreCase("tradegui")) {
+                        if (args.length >= 2 && (args[1].equalsIgnoreCase("on") || args[1].equalsIgnoreCase("off"))) {
+                            boolean enabled = args[1].equalsIgnoreCase("on");
+                            com.coflnet.config.TradeGuiManager.setEnabled(enabled);
+                            sendChatMessage("§aTrade overlay " + (enabled ? "§aenabled" : "§cdisabled")
+                                    + "§7. Open a trade to " + (enabled ? "use the SkyCofl trade GUI." : "use the normal Hypixel window."));
+                        } else {
+                            boolean current = com.coflnet.config.TradeGuiManager.isEnabled();
+                            sendChatMessage("§7Trade overlay is currently " + (current ? "§aon" : "§coff"));
+                            sendChatMessage("§7Usage: §e/cofl tradegui <on/off>");
+                        }
+                        return 1;
+                    }
+
                     // Handle sell protection commands locally
                     if (args.length >= 2 && args[0].equals("set")) {
                         if (args[1].equals("sellProtectionEnabled")) {

--- a/src/client/java/com/coflnet/config/CoflModConfig.java
+++ b/src/client/java/com/coflnet/config/CoflModConfig.java
@@ -21,6 +21,18 @@ public class CoflModConfig {
     public long sellProtectionThreshold = 1000000; // Default: 1 million coins
 
     public boolean angryCoopProtectionEnabled = true;
+
+    // Developer mode: when on, container screens show a "Copy Dump" button that
+    // copies the open container's title/size/slots to the clipboard. Off by default.
+    public boolean devMode = false;
+
+    // Trade overlay: when on, the SkyCofl TradeGUI replaces the Hypixel trade
+    // window. Independent of dev mode (which only controls the Copy Dump button).
+    public boolean tradeGuiEnabled = false;
+
+    // TradeGUI item-list column count (1-3). Persisted so the user's choice
+    // sticks across trades and restarts. Default 1 (the original look).
+    public int tradeListColumns = 1;
     
     public static CoflModConfig load() {
         try {

--- a/src/client/java/com/coflnet/config/DevManager.java
+++ b/src/client/java/com/coflnet/config/DevManager.java
@@ -1,0 +1,36 @@
+package com.coflnet.config;
+
+/**
+ * Utility class for managing developer mode configuration.
+ * When dev mode is on, container screens render a "Copy Dump" button that
+ * copies the open container's signature (title, size, slots) to the clipboard.
+ */
+public class DevManager {
+    private static CoflModConfig config = null;
+
+    private static void ensureConfig() {
+        if (config == null) {
+            config = CoflModConfig.load();
+        }
+    }
+
+    public static void reloadConfig() {
+        config = CoflModConfig.load();
+    }
+
+    public static CoflModConfig getConfig() {
+        ensureConfig();
+        return config;
+    }
+
+    public static boolean isEnabled() {
+        return getConfig().devMode;
+    }
+
+    public static void setEnabled(boolean enabled) {
+        CoflModConfig cfg = getConfig();
+        cfg.devMode = enabled;
+        cfg.save();
+        reloadConfig();
+    }
+}

--- a/src/client/java/com/coflnet/config/TradeGuiManager.java
+++ b/src/client/java/com/coflnet/config/TradeGuiManager.java
@@ -1,0 +1,49 @@
+package com.coflnet.config;
+
+/**
+ * Manages the trade overlay toggle. When enabled, the SkyCofl TradeGUI replaces
+ * the Hypixel trade window. Independent of {@link DevManager} (dev mode only
+ * controls the Copy Dump diagnostic button).
+ */
+public class TradeGuiManager {
+    private static CoflModConfig config = null;
+
+    private static void ensureConfig() {
+        if (config == null) {
+            config = CoflModConfig.load();
+        }
+    }
+
+    public static void reloadConfig() {
+        config = CoflModConfig.load();
+    }
+
+    public static CoflModConfig getConfig() {
+        ensureConfig();
+        return config;
+    }
+
+    public static boolean isEnabled() {
+        return getConfig().tradeGuiEnabled;
+    }
+
+    public static void setEnabled(boolean enabled) {
+        CoflModConfig cfg = getConfig();
+        cfg.tradeGuiEnabled = enabled;
+        cfg.save();
+        reloadConfig();
+    }
+
+    /** Persisted TradeGUI item-list column count, clamped to 1-3. */
+    public static int getListColumns() {
+        int c = getConfig().tradeListColumns;
+        return (c < 1 || c > 3) ? 1 : c;
+    }
+
+    public static void setListColumns(int columns) {
+        CoflModConfig cfg = getConfig();
+        cfg.tradeListColumns = (columns < 1 || columns > 3) ? 1 : columns;
+        cfg.save();
+        reloadConfig();
+    }
+}

--- a/src/client/java/com/coflnet/gui/trade/CoinInputGUI.java
+++ b/src/client/java/com/coflnet/gui/trade/CoinInputGUI.java
@@ -1,0 +1,338 @@
+package com.coflnet.gui.trade;
+
+import com.coflnet.CoflModClient;
+import com.coflnet.CoflModClient.WorthBasis;
+import com.coflnet.gui.RenderUtils;
+import com.coflnet.gui.cofl.CoflColConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.ContainerScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Coins input dialog for the trade overlay. Lets the user type any amount
+ * (2m, 1.5b, 80000000) OR pick one of two suggestion buttons (their side total
+ * at full LBIN value, or full Median value). On confirm, the chosen amount is
+ * stashed in {@link CoflModClient#pendingCoinAmount} and the real trade
+ * Coins-transaction slot (36) is clicked, which opens Hypixel's coin sign;
+ * the {@code openTextEdit} mixin then auto-fills that sign with the amount.
+ * <p>
+ * Returns to the {@link TradeGUI} when closed.
+ */
+public class CoinInputGUI extends Screen {
+    private static final int PAD = 10;
+    private static final int RADIUS = 4;
+    private static final int COINS_SLOT = 36;
+
+    private final ContainerScreen backing;
+    private final ChestMenu menu;
+    private final TradeGUI parent;
+
+    private final long lbinSuggestion;
+    private final long medianSuggestion;
+    // Worth of items already on MY side (per basis), subtracted from suggestions.
+    private final long myItemsLbin;
+    private final long myItemsMedian;
+
+    private EditBox input;
+    private int panelX, panelY, panelW, panelH;
+    private int lbinBtnX, lbinBtnY, medBtnX, medBtnY, sugBtnW, sugBtnH;
+    private int confirmX, confirmY, confirmW, confirmH;
+    private int cancelX, cancelY, cancelW, cancelH;
+
+    // Lowball slider: 10%–100%, default 70%. The LBIN/Med suggestion buttons
+    // multiply their full total by this percent.
+    private int sliderX, sliderY, sliderW, sliderH;
+    private int lowballPercent = 70;
+    private boolean draggingSlider = false;
+    private static final int MIN_PCT = 10;
+    private static final int MAX_PCT = 100;
+
+    public CoinInputGUI(ContainerScreen backing, TradeGUI parent) {
+        super(Component.literal("Coins Input"));
+        this.backing = backing;
+        this.menu = backing.getMenu();
+        this.parent = parent;
+        this.lbinSuggestion = sideTotal(CoflModClient.TRADE_THEIR_SLOTS, WorthBasis.LBIN);
+        this.medianSuggestion = sideTotal(CoflModClient.TRADE_THEIR_SLOTS, WorthBasis.MEDIAN);
+        // Value of items I've ALREADY put on my side (excludes coins — those are
+        // what this dialog adds). Subtracted from the suggestion so e.g. a 4m item
+        // already offered lowers a 32m lowball suggestion to 28m of coins.
+        this.myItemsLbin = sideItemsOnly(CoflModClient.TRADE_YOUR_SLOTS, WorthBasis.LBIN);
+        this.myItemsMedian = sideItemsOnly(CoflModClient.TRADE_YOUR_SLOTS, WorthBasis.MEDIAN);
+    }
+
+    /** Full-value total of a side for a basis (offered coins count at face value). */
+    private long sideTotal(int[] slots, WorthBasis basis) {
+        long total = 0;
+        for (int slot : slots) {
+            if (slot >= menu.slots.size()) {
+                continue;
+            }
+            ItemStack stack = menu.slots.get(slot).getItem();
+            if (stack.isEmpty() || stack.getItem() == Items.AIR) {
+                continue;
+            }
+            Long coins = CoflModClient.parseCoinStack(stack);
+            if (coins != null) {
+                total += coins;
+                continue;
+            }
+            String id = CoflModClient.getIdFromStack(stack);
+            Long worth = CoflModClient.parseWorthFromTips(
+                    CoflCore.handlers.DescriptionHandler.getTooltipData(id), basis);
+            if (worth != null) {
+                total += worth * stack.getCount();
+            }
+        }
+        return total;
+    }
+
+    /** Worth of a side's ITEMS only (ignores any coins already in those slots). */
+    private long sideItemsOnly(int[] slots, WorthBasis basis) {
+        long total = 0;
+        for (int slot : slots) {
+            if (slot >= menu.slots.size()) {
+                continue;
+            }
+            ItemStack stack = menu.slots.get(slot).getItem();
+            if (stack.isEmpty() || stack.getItem() == Items.AIR) {
+                continue;
+            }
+            if (CoflModClient.parseCoinStack(stack) != null) {
+                continue; // skip coins
+            }
+            String id = CoflModClient.getIdFromStack(stack);
+            Long worth = CoflModClient.parseWorthFromTips(
+                    CoflCore.handlers.DescriptionHandler.getTooltipData(id), basis);
+            if (worth != null) {
+                total += worth * stack.getCount();
+            }
+        }
+        return total;
+    }
+
+    @Override
+    protected void init() {
+        panelW = 220;
+        panelH = 164;
+        panelX = this.width / 2 - panelW / 2;
+        panelY = this.height / 2 - panelH / 2;
+
+        Font font = Minecraft.getInstance().font;
+        input = new EditBox(font, panelX + PAD, panelY + 28, panelW - PAD * 2, 16, Component.literal("amount"));
+        input.setMaxLength(20);
+        input.setValue("");
+        addRenderableWidget(input);
+        setInitialFocus(input);
+
+        // Lowball slider — pushed below the input box (input ends at +44; its
+        // label sits at +52, the track at +64) so they no longer overlap.
+        sliderX = panelX + PAD;
+        sliderY = panelY + 68;
+        sliderW = panelW - PAD * 2;
+        sliderH = 8;
+
+        sugBtnW = (panelW - PAD * 3) / 2;
+        sugBtnH = 18;
+        lbinBtnX = panelX + PAD;
+        lbinBtnY = panelY + 90;
+        medBtnX = lbinBtnX + sugBtnW + PAD;
+        medBtnY = lbinBtnY;
+
+        confirmW = (panelW - PAD * 3) / 2;
+        confirmH = 18;
+        confirmX = panelX + PAD;
+        confirmY = panelY + panelH - PAD - confirmH;
+        cancelW = confirmW;
+        cancelH = confirmH;
+        cancelX = confirmX + confirmW + PAD;
+        cancelY = confirmY;
+    }
+
+    /**
+     * Coins to suggest = (their total × lowball%) − value of items I already
+     * offered on my side, clamped at 0. So if I add a 4m item, the coin
+     * suggestion drops by 4m. {@code myItems} must match the {@code fullTotal}
+     * basis (LBIN total ⇄ LBIN of my items).
+     */
+    private long scaled(long fullTotal, long myItems) {
+        long target = fullTotal * lowballPercent / 100L;
+        return Math.max(0L, target - myItems);
+    }
+
+    @Override
+    public void extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        RenderUtils.drawRoundedRect(context, panelX, panelY, panelW, panelH, RADIUS, CoflColConfig.BACKGROUND_PRIMARY);
+        RenderUtils.drawString(context, "§lAdd Coins", panelX + PAD, panelY + PAD, CoflColConfig.TEXT_PRIMARY);
+
+        // Lowball slider.
+        RenderUtils.drawString(context, "§7Lowball: §f" + lowballPercent + "%", sliderX, sliderY - 10, CoflColConfig.TEXT_PRIMARY);
+        RenderUtils.drawRoundedRect(context, sliderX, sliderY, sliderW, sliderH, 2, CoflColConfig.BACKGROUND_SECONDARY);
+        int knobX = sliderX + (int) ((long) (lowballPercent - MIN_PCT) * (sliderW - 6) / (MAX_PCT - MIN_PCT));
+        RenderUtils.drawRoundedRect(context, knobX, sliderY - 2, 6, sliderH + 4, 2, CoflColConfig.CONFIRM);
+
+        // Suggestion buttons (scaled by the lowball percent).
+        drawButton(context, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
+                "LBIN " + fmt(scaled(lbinSuggestion, myItemsLbin)), CoflColConfig.BACKGROUND_SECONDARY, CoflColConfig.CONFIRM_HOVER);
+        drawButton(context, medBtnX, medBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
+                "Med " + fmt(scaled(medianSuggestion, myItemsMedian)), CoflColConfig.BACKGROUND_SECONDARY, CoflColConfig.CONFIRM_HOVER);
+
+        // Confirm / cancel.
+        drawButton(context, confirmX, confirmY, confirmW, confirmH, mouseX, mouseY,
+                "Confirm", CoflColConfig.CONFIRM, CoflColConfig.CONFIRM_HOVER);
+        drawButton(context, cancelX, cancelY, cancelW, cancelH, mouseX, mouseY,
+                "Cancel", CoflColConfig.CANCEL, CoflColConfig.CANCEL_HOVER);
+    }
+
+    private void drawButton(GuiGraphicsExtractor context, int x, int y, int w, int h, int mx, int my,
+                            String label, int base, int hover) {
+        boolean over = mx >= x && mx < x + w && my >= y && my < y + h;
+        RenderUtils.drawRoundedRect(context, x, y, w, h, 2, over ? hover : base);
+        RenderUtils.drawCenteredString(context, label, x + w / 2, y + 5, CoflColConfig.TEXT_PRIMARY);
+    }
+
+    @Override
+    public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
+        double mx = click.x();
+        double my = click.y();
+
+        // Slider grab (generous vertical hit area).
+        if (inRect(mx, my, sliderX, sliderY - 4, sliderW, sliderH + 8)) {
+            draggingSlider = true;
+            updateSlider(mx);
+            return true;
+        }
+        if (inRect(mx, my, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH)) {
+            input.setValue(String.valueOf(scaled(lbinSuggestion, myItemsLbin)));
+            return true;
+        }
+        if (inRect(mx, my, medBtnX, medBtnY, sugBtnW, sugBtnH)) {
+            input.setValue(String.valueOf(scaled(medianSuggestion, myItemsMedian)));
+            return true;
+        }
+        if (inRect(mx, my, confirmX, confirmY, confirmW, confirmH)) {
+            submit();
+            return true;
+        }
+        if (inRect(mx, my, cancelX, cancelY, cancelW, cancelH)) {
+            returnToTrade();
+            return true;
+        }
+        return super.mouseClicked(click, doubled);
+    }
+
+    @Override
+    public boolean mouseDragged(MouseButtonEvent click, double dragX, double dragY) {
+        if (draggingSlider) {
+            updateSlider(click.x());
+            return true;
+        }
+        return super.mouseDragged(click, dragX, dragY);
+    }
+
+    @Override
+    public boolean mouseReleased(MouseButtonEvent click) {
+        draggingSlider = false;
+        return super.mouseReleased(click);
+    }
+
+    /** Maps a mouse-x onto the slider track and snaps the lowball percent. */
+    private void updateSlider(double mx) {
+        double frac = (mx - sliderX) / (double) (sliderW - 6);
+        frac = Math.max(0.0, Math.min(1.0, frac));
+        lowballPercent = MIN_PCT + (int) Math.round(frac * (MAX_PCT - MIN_PCT));
+        // Snap to the nearest 5% for tidy values.
+        lowballPercent = Math.round(lowballPercent / 5.0f) * 5;
+        lowballPercent = Math.max(MIN_PCT, Math.min(MAX_PCT, lowballPercent));
+    }
+
+    /** Parses the typed value, stashes it, and clicks the real coins slot. */
+    private void submit() {
+        String raw = input.getValue() == null ? "" : input.getValue().trim();
+        Long amount = parseAmount(raw);
+        if (amount == null || amount <= 0) {
+            return; // invalid input — leave dialog open
+        }
+        CoflModClient.pendingCoinAmount = String.valueOf(amount);
+        // Return to trade first so the sign editor (opened by the click) layers
+        // over the trade, then click the real coins-transaction slot.
+        Minecraft client = Minecraft.getInstance();
+        Player player = client.player;
+        returnToTrade();
+        if (player != null) {
+            client.gameMode.handleContainerInput(menu.containerId, COINS_SLOT, 0, ContainerInput.PICKUP, player);
+        }
+    }
+
+    private void returnToTrade() {
+        Minecraft.getInstance().gui.setScreen(parent);
+    }
+
+    /** Accepts plain digits and k/m/b suffixes (2m, 1.5b, 80000000). */
+    static Long parseAmount(String s) {
+        if (s == null || s.isEmpty()) {
+            return null;
+        }
+        String in = s.toLowerCase().replace(",", "").trim();
+        try {
+            if (in.matches("^[0-9]+$")) {
+                return Long.parseLong(in);
+            }
+            if (in.matches("^[0-9]*\\.?[0-9]+[kmb]$")) {
+                char suf = in.charAt(in.length() - 1);
+                double val = Double.parseDouble(in.substring(0, in.length() - 1));
+                return switch (suf) {
+                    case 'k' -> (long) (val * 1_000L);
+                    case 'm' -> (long) (val * 1_000_000L);
+                    case 'b' -> (long) (val * 1_000_000_000L);
+                    default -> null;
+                };
+            }
+            if (in.matches("^[0-9]+\\.[0-9]+$")) {
+                return (long) Double.parseDouble(in);
+            }
+        } catch (NumberFormatException e) {
+            return null;
+        }
+        return null;
+    }
+
+    private static boolean inRect(double px, double py, int x, int y, int w, int h) {
+        return px >= x && px < x + w && py >= y && py < y + h;
+    }
+
+    private static String fmt(long coins) {
+        if (coins >= 1_000_000_000L) {
+            return String.format(java.util.Locale.US, "%.1fB", coins / 1_000_000_000.0);
+        } else if (coins >= 1_000_000L) {
+            return String.format(java.util.Locale.US, "%.1fM", coins / 1_000_000.0);
+        } else if (coins >= 1_000L) {
+            return String.format(java.util.Locale.US, "%.1fK", coins / 1_000.0);
+        }
+        return String.valueOf(coins);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    @Override
+    public void onClose() {
+        // Esc returns to the trade rather than closing the whole trade.
+        returnToTrade();
+    }
+}

--- a/src/client/java/com/coflnet/gui/trade/TradeGUI.java
+++ b/src/client/java/com/coflnet/gui/trade/TradeGUI.java
@@ -1,0 +1,755 @@
+package com.coflnet.gui.trade;
+
+import com.coflnet.CoflModClient;
+import com.coflnet.CoflModClient.WorthBasis;
+import com.coflnet.gui.RenderUtils;
+import com.coflnet.gui.cofl.CoflColConfig;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.ContainerScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.core.NonNullList;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.ChestMenu;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import org.lwjgl.glfw.GLFW;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Full-replacement overlay for the Hypixel trade window.
+ * <p>
+ * Layout: a wide trade panel (two scrollable item tables separated by a vertical
+ * splitter) on top. Below it the player inventory is right-aligned to the panel,
+ * with the profit box (gray outline), Accept button, and the other player's
+ * pending-confirm status stacked to the LEFT of the inventory. Item rows are
+ * gray; only the YOU / other-player headers are colored. Tables are scissor-
+ * clipped so scrolled items never bleed over the headers or buttons.
+ */
+public class TradeGUI extends Screen {
+    private static final int PAD = 10;
+    private static final int RADIUS = 4;
+    private static final int ROW_H = 20;
+    private static final int ITEM = 16;
+    private static final int INV_CELL = 25;
+
+    private static final int SEPARATOR = 0xFF55606B;
+    private static final int ROW_TINT = 0xFF2C323B;
+    private static final int DISABLED = 0xFF555B63;
+
+    private final ContainerScreen backing;
+    private final ChestMenu menu;
+    private final String otherName;
+
+    private WorthBasis basis = WorthBasis.LBIN;
+
+    private int panelX, panelY, panelW, panelH;
+    private int colYouX, colThemX, colW;
+    private int splitterX;
+    private int tableTop, tableBottom;
+    private int invGridX, invGridY;
+    private int invBlockX, invBlockY, invBlockW, invBlockH;
+    private int basisBtnX, basisBtnY, basisBtnW, basisBtnH;
+    private int acceptBtnX, acceptBtnY, acceptBtnW, acceptBtnH;
+    private int coinsBtnX, coinsBtnY, coinsBtnW, coinsBtnH;
+    private int profitX, profitY, profitW, profitH;
+    private int ctrlX, ctrlY, ctrlW, ctrlH;
+    private int statusX, statusY;
+    private int settBtnX, settBtnY, settBtnW, settBtnH;
+
+    // Layout option (changed via the control-panel settings button): how many
+    // columns the item list uses. Default 1 (the original look). 2–3 columns use
+    // compact, shorter rows so many items are easier to see at once. Persisted in
+    // CoflModConfig so the choice survives across trades and restarts.
+    private int listColumns = com.coflnet.config.TradeGuiManager.getListColumns();
+    private static final int MAX_COLUMNS = 3;
+    private boolean settingsOpen = false;
+
+    private int scrollYou = 0;
+    private int scrollThem = 0;
+
+    // Lag fix: instead of polling the heavy backend pipeline every second from
+    // the render thread, we detect changes with a CHEAP signature of just the
+    // trade slots and only re-price OFF-thread when that signature changes.
+    private String lastTradeSig = null;
+    private volatile boolean repriceInFlight = false;
+
+    private record Row(int slotId, ItemStack stack, boolean isCoins, long coinAmount) {}
+
+    public TradeGUI(ContainerScreen backing) {
+        super(Component.literal("SkyCofl Trade"));
+        this.backing = backing;
+        this.menu = backing.getMenu();
+        this.otherName = resolveOtherName(backing.getTitle().getString());
+    }
+
+    /**
+     * Resolves the other player's name. Prefers the full IGN captured from the
+     * trade-request chat line; falls back to the (possibly truncated) title name.
+     */
+    private static String resolveOtherName(String title) {
+        String fromChat = CoflModClient.lastTradePartner;
+        if (fromChat != null && !fromChat.isEmpty()) {
+            return fromChat;
+        }
+        return extractOtherName(title);
+    }
+
+    private static String extractOtherName(String title) {
+        if (title == null) {
+            return "THEM";
+        }
+        String t = ChatStrip(title).trim();
+        if (t.startsWith("You")) {
+            t = t.substring(3);
+        }
+        t = t.trim();
+        return t.isEmpty() ? "THEM" : t;
+    }
+
+    /**
+     * Cheap per-frame change detection over just the trade slots (both sides).
+     * Builds a tiny string of itemId×count per non-empty trade slot — no NBT,
+     * no gzip, no base64. Only when this signature changes do we fire the heavy
+     * backend re-price, and we do it on a virtual thread so the render thread
+     * never blocks (root cause of the add/remove FPS spikes).
+     */
+    private void maybeReprice() {
+        StringBuilder sig = new StringBuilder();
+        appendSig(sig, CoflModClient.TRADE_YOUR_SLOTS);
+        appendSig(sig, CoflModClient.TRADE_THEIR_SLOTS);
+        String current = sig.toString();
+        if (current.equals(lastTradeSig)) {
+            return;
+        }
+        // Check the in flight flag before we advance lastTradeSig, so a change
+        // that lands while a reprice is running is not swallowed. We leave
+        // lastTradeSig on the old value and just bail, and then the next frame
+        // still sees a mismatch and fires the reprice once the slot is free.
+        if (repriceInFlight) {
+            return;
+        }
+        lastTradeSig = current;
+        repriceInFlight = true;
+        final String title = backing.getTitle().getString();
+        final NonNullList<ItemStack> snapshot = NonNullList.create();
+        snapshot.addAll(menu.getItems());
+        Thread.startVirtualThread(() -> {
+            try {
+                CoflModClient.loadDescriptionsForItems(title, snapshot);
+            } catch (Exception ignored) {
+            } finally {
+                repriceInFlight = false;
+            }
+        });
+    }
+
+    private void appendSig(StringBuilder sig, int[] slots) {
+        for (int slot : slots) {
+            if (slot >= menu.slots.size()) {
+                continue;
+            }
+            ItemStack stack = menu.slots.get(slot).getItem();
+            if (stack.isEmpty()) {
+                continue;
+            }
+            sig.append(slot).append(':')
+               .append(CoflModClient.getIdFromStack(stack)).append('x')
+               .append(stack.getCount()).append(';');
+        }
+    }
+
+    @Override
+    protected void init() {
+        panelW = Math.min(this.width - 24, 520);
+        panelX = this.width / 2 - panelW / 2;
+
+        int innerW = panelW - PAD * 2;
+        colW = (innerW - PAD) / 2;
+        colYouX = panelX + PAD;
+        colThemX = colYouX + colW + PAD;
+        splitterX = colYouX + colW + PAD / 2;
+
+        int invRows = 4;
+        int invW = 9 * INV_CELL + 8;
+        int invH = invRows * INV_CELL + 8;
+
+        int headerH = 32;   // smaller now that the basis toggle moves to the control bar
+        // Bottom bar inside the panel: totals row + margin + Add Coins button,
+        // with equal padding all around (fixes the lopsided bottom gap).
+        int totalsH = 12;
+        int coinsMargin = 8;
+        int coinsH = 18;
+        int bottomBarH = totalsH + coinsMargin + coinsH;
+
+        int belowBlockH = invH;  // inventory + side controls share this height
+        int fixed = headerH + bottomBarH + PAD * 2 + 10 + belowBlockH + 12;
+        int avail = this.height - fixed;
+        int maxTablesH = 5 * ROW_H + 6;
+        int tablesH = Math.max(2 * ROW_H, Math.min(maxTablesH, avail));
+        panelH = headerH + tablesH + bottomBarH + PAD;
+
+        int totalH = panelH + 10 + belowBlockH;
+        panelY = Math.max(6, this.height / 2 - totalH / 2);
+
+        tableTop = panelY + headerH;
+        tableBottom = panelY + headerH + tablesH;
+
+        // Add Coins button — equal padding (PAD) on sides and bottom, margin above.
+        coinsBtnW = panelW - PAD * 2;
+        coinsBtnH = coinsH;
+        coinsBtnX = panelX + PAD;
+        coinsBtnY = panelY + panelH - PAD - coinsH;
+
+        // --- Below the panel ---
+        // Inventory right-aligned to the panel's right edge.
+        invBlockW = invW;
+        invBlockH = invH;
+        invBlockX = panelX + panelW - invW;
+        invBlockY = panelY + panelH + 10;
+        invGridX = invBlockX + 4;
+        invGridY = invBlockY + 4;
+
+        // Control bar: its own gray bordered box to the LEFT of the inventory,
+        // spanning from the panel's left edge up to (not merging with) the
+        // inventory. Holds profit, basis toggle, Accept, and pending status.
+        ctrlX = panelX;
+        ctrlY = invBlockY;
+        ctrlW = invBlockX - 8 - panelX;   // reach the inventory but keep an 8px gap
+        ctrlH = invBlockH;
+
+        // Settings button in the control panel's top-right corner.
+        settBtnW = 14;
+        settBtnH = 14;
+        settBtnX = ctrlX + ctrlW - settBtnW - 4;
+        settBtnY = ctrlY + 4;
+
+        int inX = ctrlX + 6;
+        int inW = ctrlW - 12;
+
+        profitX = inX;
+        profitY = ctrlY + 6;
+        profitW = inW;
+        profitH = 32;
+
+        // Basis toggle moved here (was top-right of the panel).
+        basisBtnX = inX;
+        basisBtnY = profitY + profitH + 4;
+        basisBtnW = inW;
+        basisBtnH = 14;
+
+        acceptBtnX = inX;
+        acceptBtnY = basisBtnY + basisBtnH + 4;
+        acceptBtnW = inW;
+        acceptBtnH = 20;
+
+        statusX = inX;
+        statusY = acceptBtnY + acceptBtnH + 4;
+    }
+
+    private List<Row> buildRows(int[] slots) {
+        List<Row> rows = new ArrayList<>();
+        for (int slot : slots) {
+            if (slot >= menu.slots.size()) {
+                continue;
+            }
+            ItemStack stack = menu.slots.get(slot).getItem();
+            if (stack.isEmpty() || stack.getItem() == Items.AIR) {
+                continue;
+            }
+            Long coins = CoflModClient.parseCoinStack(stack);
+            rows.add(new Row(slot, stack, coins != null, coins == null ? 0L : coins));
+        }
+        return rows;
+    }
+
+    private long rowWorth(Row row) {
+        if (row.isCoins()) {
+            return row.coinAmount();
+        }
+        String id = CoflModClient.getIdFromStack(row.stack());
+        Long w = CoflModClient.parseWorthFromTips(
+                CoflCore.handlers.DescriptionHandler.getTooltipData(id), basis);
+        return (w == null ? 0L : w) * row.stack().getCount();
+    }
+
+    private long sideTotal(List<Row> rows) {
+        long total = 0;
+        for (Row r : rows) {
+            total += rowWorth(r);
+        }
+        return total;
+    }
+
+    @Override
+    public void extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        if (Minecraft.getInstance().getConnection() == null || backing.getMenu() != this.menu) {
+            onClose();
+            return;
+        }
+        Font font = Minecraft.getInstance().font;
+
+        // Re-price ONLY when the trade contents actually change, and do the heavy
+        // backend call OFF the render thread. The old code serialized all 45 slots
+        // to NBT+gzip+base64 and hit the backend synchronously every second on the
+        // render thread → multi-second FPS-to-0 spikes on every add/remove.
+        maybeReprice();
+
+        List<Row> youRows = buildRows(CoflModClient.TRADE_YOUR_SLOTS);
+        List<Row> themRows = buildRows(CoflModClient.TRADE_THEIR_SLOTS);
+        long youTotal = sideTotal(youRows);
+        long themTotal = sideTotal(themRows);
+
+        RenderUtils.drawRoundedRect(context, panelX, panelY, panelW, panelH, RADIUS, CoflColConfig.BACKGROUND_PRIMARY);
+        RenderUtils.drawString(context, "§lSkyCofl Trade", panelX + PAD, panelY + PAD, CoflColConfig.TEXT_PRIMARY);
+
+        // Header bars gray; YOU label green (left), other name red + RIGHT-aligned, full name.
+        int barY = panelY + PAD + 8;
+        RenderUtils.drawRoundedRect(context, colYouX, barY, colW, 12, 2, CoflColConfig.BACKGROUND_SECONDARY);
+        RenderUtils.drawRoundedRect(context, colThemX, barY, colW, 12, 2, CoflColConfig.BACKGROUND_SECONDARY);
+        RenderUtils.drawString(context, "§aYou", colYouX + 4, barY + 2, CoflColConfig.TEXT_PRIMARY);
+        int nameW = font.width(otherName);
+        RenderUtils.drawString(context, "§c" + otherName, colThemX + colW - nameW - 4, barY + 2, CoflColConfig.TEXT_PRIMARY);
+
+        RenderUtils.drawRect(context, splitterX, tableTop - 2, 1, (tableBottom - tableTop) + 4, SEPARATOR);
+
+        // Scissor-clip each table so scrolled items stay inside the viewport.
+        context.enableScissor(colYouX, tableTop, colYouX + colW, tableBottom);
+        drawSide(context, font, youRows, colYouX, scrollYou, mouseX, mouseY);
+        context.disableScissor();
+        context.enableScissor(colThemX, tableTop, colThemX + colW, tableBottom);
+        drawSide(context, font, themRows, colThemX, scrollThem, mouseX, mouseY);
+        context.disableScissor();
+
+        // Scrollbars (outside the scissor so they always show).
+        drawScrollbar(context, colYouX, scrollYou, youRows.size());
+        drawScrollbar(context, colThemX, scrollThem, themRows.size());
+
+        // Totals row under the tables.
+        RenderUtils.drawString(context, "§7You: §f" + fmt(youTotal), colYouX, tableBottom + 3, CoflColConfig.TEXT_PRIMARY);
+        RenderUtils.drawString(context, "§7" + otherName + ": §f" + fmt(themTotal), colThemX, tableBottom + 3, CoflColConfig.TEXT_PRIMARY);
+
+        // Add Coins button (clear of the items thanks to the margin + clip).
+        boolean coinsHover = inRect(mouseX, mouseY, coinsBtnX, coinsBtnY, coinsBtnW, coinsBtnH);
+        RenderUtils.drawRoundedRect(context, coinsBtnX, coinsBtnY, coinsBtnW, coinsBtnH, 2,
+                coinsHover ? CoflColConfig.CONFIRM_HOVER : CoflColConfig.BACKGROUND_SECONDARY);
+        RenderUtils.drawCenteredString(context, "Add Coins", coinsBtnX + coinsBtnW / 2, coinsBtnY + 5, CoflColConfig.TEXT_PRIMARY);
+
+        // --- Below the panel: control bar (left) + inventory (right) ---
+        TradeState state = readTradeState();
+        long net = themTotal - youTotal;
+        String netStr = (net >= 0) ? "§aProfit +" + fmt(net) : "§cLosing -" + fmt(-net);
+
+        // Control bar: its own gray box (NO border — borders only used on the
+        // profit box, matching the rest of the trade UI).
+        RenderUtils.drawRoundedRect(context, ctrlX, ctrlY, ctrlW, ctrlH, RADIUS, CoflColConfig.BACKGROUND_PRIMARY);
+
+        // Settings button (top-right of the control panel).
+        boolean settHover = inRect(mouseX, mouseY, settBtnX, settBtnY, settBtnW, settBtnH);
+        RenderUtils.drawRoundedRect(context, settBtnX, settBtnY, settBtnW, settBtnH, 2,
+                settHover ? CoflColConfig.CONFIRM_HOVER : CoflColConfig.BACKGROUND_SECONDARY);
+        RenderUtils.drawCenteredString(context, "⚙", settBtnX + settBtnW / 2, settBtnY + 3, CoflColConfig.TEXT_PRIMARY);
+
+        // Net profit/loss only (no outline, no You/They give lines — those are
+        // visible in the trade tables' totals already, and the box was crowding
+        // the settings gear). Just the bottom line, the thing that matters.
+        RenderUtils.drawString(context, netStr, profitX, profitY + 2, CoflColConfig.TEXT_PRIMARY);
+
+        // Basis toggle (moved here from the top-right).
+        boolean basisHover = inRect(mouseX, mouseY, basisBtnX, basisBtnY, basisBtnW, basisBtnH);
+        RenderUtils.drawRoundedRect(context, basisBtnX, basisBtnY, basisBtnW, basisBtnH, 2,
+                basisHover ? CoflColConfig.CONFIRM_HOVER : CoflColConfig.BACKGROUND_SECONDARY);
+        RenderUtils.drawCenteredString(context, (basis == WorthBasis.LBIN ? "Basis: LBIN (click)" : "Basis: Med (click)"),
+                basisBtnX + basisBtnW / 2, basisBtnY + 3, CoflColConfig.TEXT_PRIMARY);
+
+        // Accept button.
+        boolean acceptHover = inRect(mouseX, mouseY, acceptBtnX, acceptBtnY, acceptBtnW, acceptBtnH);
+        int acceptCol = state.onCooldown ? DISABLED : (acceptHover ? CoflColConfig.CONFIRM_HOVER : CoflColConfig.CONFIRM);
+        RenderUtils.drawRoundedRect(context, acceptBtnX, acceptBtnY, acceptBtnW, acceptBtnH, 2, acceptCol);
+        RenderUtils.drawCenteredString(context, "Accept", acceptBtnX + acceptBtnW / 2, acceptBtnY + 6, 0xFF222831);
+
+        // Pending confirmation row.
+        String statusLine = "§7" + otherName + ": " + state.themStatus;
+        RenderUtils.drawString(context, truncate(font, ChatStrip(statusLine), ctrlW - 12), statusX, statusY, CoflColConfig.TEXT_PRIMARY);
+        if (!state.youRaw.isEmpty()) {
+            RenderUtils.drawString(context, "§8" + truncate(font, state.youRaw, ctrlW - 12), statusX, statusY + 9, CoflColConfig.TEXT_PRIMARY);
+        }
+
+        // Inventory block (right-aligned). Items scaled up to fill the bigger cells.
+        RenderUtils.drawRoundedRect(context, invBlockX, invBlockY, invBlockW, invBlockH, RADIUS, CoflColConfig.BACKGROUND_PRIMARY);
+        float itemScale = (INV_CELL - 4) / (float) ITEM;   // grow the 16px icon to ~the cell
+        for (int i = 45; i < menu.slots.size(); i++) {
+            int[] rect = invSlotRect(i);
+            if (rect == null) {
+                continue;
+            }
+            RenderUtils.drawRect(context, rect[0], rect[1], INV_CELL - 3, INV_CELL - 3, CoflColConfig.BACKGROUND_SECONDARY);
+            ItemStack stack = menu.slots.get(i).getItem();
+            if (!stack.isEmpty() && stack.getItem() != Items.AIR) {
+                drawScaledItem(context, stack, rect[0] + 1, rect[1] + 1, itemScale);
+                if (inRect(mouseX, mouseY, rect[0], rect[1], INV_CELL - 3, INV_CELL - 3)) {
+                    context.setTooltipForNextFrame(font, stack, mouseX, mouseY);
+                }
+            }
+        }
+
+        ItemStack carried = menu.getCarried();
+        if (!carried.isEmpty()) {
+            RenderUtils.drawItemStack(context, carried, mouseX - 8, mouseY - 8, 1);
+        }
+
+        // Settings dropdown — drawn LAST so it sits on top of everything.
+        if (settingsOpen) {
+            int[] r = settingsRowRect();
+            int boxY = settBtnY + settBtnH + 2;
+            RenderUtils.drawRoundedRect(context, r[0], boxY, r[2], r[3] + 4, 3, CoflColConfig.BACKGROUND_SECONDARY);
+            boolean rowHover = inRect(mouseX, mouseY, r[0], r[1], r[2], r[3]);
+            RenderUtils.drawRoundedRect(context, r[0] + 2, r[1], r[2] - 4, r[3], 2,
+                    rowHover ? CoflColConfig.CONFIRM_HOVER : CoflColConfig.BACKGROUND_PRIMARY);
+            String label = "Columns: " + listColumns + " (click)";
+            RenderUtils.drawString(context, label, r[0] + 6, r[1] + 3, CoflColConfig.TEXT_PRIMARY);
+        }
+    }
+
+    /** Rect [x,y,w,h] of the single settings dropdown row (the 1/2-column toggle). */
+    private int[] settingsRowRect() {
+        int w = Math.max(110, settBtnW + 96);
+        int x = settBtnX + settBtnW - w;     // right-aligned under the gear
+        int y = settBtnY + settBtnH + 4;
+        return new int[]{x, y, w, 13};
+    }
+
+    /** Draws an item icon scaled up via the pose matrix (vanilla render is fixed 16px). */
+    private void drawScaledItem(GuiGraphicsExtractor context, ItemStack stack, int x, int y, float scale) {
+        var pose = context.pose();
+        pose.pushMatrix();
+        pose.translate(x, y);
+        pose.scale(scale, scale);
+        RenderUtils.drawItemStack(context, stack, 0, 0, 1);
+        pose.popMatrix();
+    }
+
+    private void drawScrollbar(GuiGraphicsExtractor context, int x, int scroll, int rowCount) {
+        int contentH = contentHeight(rowCount);
+        int viewH = tableBottom - tableTop;
+        if (contentH <= viewH) {
+            return;
+        }
+        int trackX = x + colW - 3;
+        int barH = Math.max(12, (int) ((long) viewH * viewH / contentH));
+        int maxScroll = contentH - viewH;
+        int barY = tableTop + (maxScroll <= 0 ? 0 : (int) ((long) scroll * (viewH - barH) / maxScroll));
+        RenderUtils.drawRect(context, trackX, tableTop, 3, viewH, CoflColConfig.BACKGROUND_PRIMARY);
+        RenderUtils.drawRect(context, trackX, barY, 3, barH, CoflColConfig.TEXT_PRIMARY);
+    }
+
+    /** Total pixel height of the item list for a row count, accounting for columns. */
+    private int contentHeight(int rowCount) {
+        int lines = (rowCount + cols() - 1) / cols();
+        return lines * cellH();
+    }
+
+    // --- Item list grid metrics (depend on listColumns) ---
+    private boolean compact() {
+        return listColumns > 1;
+    }
+
+    private int cols() {
+        return listColumns;
+    }
+
+    private int cellW() {
+        return (colW - (cols() - 1) * 2) / cols();
+    }
+
+    private int cellH() {
+        return compact() ? 14 : ROW_H;
+    }
+
+    private void drawSide(GuiGraphicsExtractor context, Font font, List<Row> rows, int x, int scroll, int mouseX, int mouseY) {
+        int cols = cols();
+        int cellW = cellW();
+        int cellH = cellH();
+        int idx = 0;
+        for (Row row : rows) {
+            int col = idx % cols;
+            int line = idx / cols;
+            int cx = x + col * (cellW + 2);
+            int cy = tableTop - scroll + line * cellH;
+            idx++;
+            if (cy + cellH < tableTop || cy > tableBottom) {
+                continue;
+            }
+            boolean hover = inRect(mouseX, mouseY, cx, cy, cellW, cellH) && mouseY >= tableTop && mouseY <= tableBottom;
+            RenderUtils.drawRect(context, cx, cy, cellW, cellH - 1, hover ? CoflColConfig.BACKGROUND_SECONDARY : ROW_TINT);
+            RenderUtils.drawRect(context, cx, cy + cellH - 1, cellW, 1, SEPARATOR);
+
+            if (!row.isCoins()) {
+                if (compact()) {
+                    // shrink the 16px icon to fit the shorter row
+                    drawScaledItem(context, row.stack(), cx + 1, cy + 1, (cellH - 3) / (float) ITEM);
+                } else {
+                    RenderUtils.drawItemStack(context, row.stack(), cx + 1, cy + 2, 1);
+                }
+            }
+            int iconW = compact() ? (cellH - 2) : ITEM;
+            String name = row.isCoins() ? "Coins" : ChatStrip(row.stack().getHoverName().getString());
+            String worth = row.isCoins() ? fmtFull(row.coinAmount()) : fmt(rowWorth(row));
+            int worthW = font.width(worth);
+            int textX = cx + iconW + 3;
+            int worthCol = row.isCoins() ? 0xFFFFD24A : 0xFFFFC832;
+
+            if (compact()) {
+                // One compact line: name (truncated) then worth right-aligned.
+                int maxNameW = cellW - iconW - 6 - worthW - 4;
+                RenderUtils.drawString(context, truncate(font, name, maxNameW), textX, cy + 3, CoflColConfig.TEXT_PRIMARY);
+                RenderUtils.drawString(context, worth, cx + cellW - worthW - 3, cy + 3, worthCol);
+            } else {
+                int maxNameW = cellW - iconW - 8 - worthW - 8;
+                RenderUtils.drawString(context, truncate(font, name, maxNameW), textX, cy + 2, CoflColConfig.TEXT_PRIMARY);
+                RenderUtils.drawString(context, worth, cx + cellW - worthW - 6, cy + 11, worthCol);
+            }
+
+            if (hover && !row.isCoins()) {
+                context.setTooltipForNextFrame(font, row.stack(), mouseX, mouseY);
+            }
+        }
+    }
+
+    private TradeState readTradeState() {
+        TradeState s = new TradeState();
+        String you = slotName(39);
+        String them = slotName(41);
+        s.youRaw = you == null ? "" : you;
+        s.onCooldown = you != null && you.toLowerCase().contains("timer");
+
+        if (them != null && them.toLowerCase().contains("confirmed")) {
+            s.themStatus = "§aThey accepted";
+        } else if (them != null && them.toLowerCase().contains("timer")) {
+            s.themStatus = "§7Cooldown" + extractParens(them);
+        } else if (them != null && !them.isEmpty()) {
+            s.themStatus = "§7" + them;
+        } else {
+            s.themStatus = "§7Waiting…";
+        }
+        return s;
+    }
+
+    private static class TradeState {
+        boolean onCooldown = false;
+        String youRaw = "";
+        String themStatus = "§7Waiting…";
+    }
+
+    private String slotName(int slot) {
+        if (slot >= menu.slots.size()) {
+            return null;
+        }
+        ItemStack stack = menu.slots.get(slot).getItem();
+        if (stack.isEmpty()) {
+            return null;
+        }
+        return ChatStrip(stack.getHoverName().getString());
+    }
+
+    private static String extractParens(String s) {
+        int a = s.indexOf('(');
+        int b = s.indexOf(')');
+        return (a >= 0 && b > a) ? " " + s.substring(a, b + 1) : "";
+    }
+
+    private int[] invSlotRect(int slotId) {
+        int inv = slotId - 45;
+        if (inv < 0) {
+            return null;
+        }
+        if (inv < 27) {
+            return new int[]{invGridX + (inv % 9) * INV_CELL, invGridY + (inv / 9) * INV_CELL};
+        }
+        int hot = inv - 27;
+        return new int[]{invGridX + hot * INV_CELL, invGridY + 3 * INV_CELL + 4};
+    }
+
+    @Override
+    public boolean mouseClicked(MouseButtonEvent click, boolean doubled) {
+        double mx = click.x();
+        double my = click.y();
+        int button = click.button();
+        boolean shift = (click.modifiers() & GLFW.GLFW_MOD_SHIFT) != 0;
+
+        // Settings dropdown (drawn on top, so handle its hits first).
+        if (settingsOpen) {
+            int[] r = settingsRowRect();
+            if (inRect(mx, my, r[0], r[1], r[2], r[3])) {
+                listColumns = (listColumns % MAX_COLUMNS) + 1;  // cycle 1 -> 2 -> 3 -> 1
+                // Persist the choice so it sticks across trades and restarts.
+                com.coflnet.config.TradeGuiManager.setListColumns(listColumns);
+                scrollYou = 0;
+                scrollThem = 0;
+                return true;
+            }
+            // Click anywhere else closes the dropdown.
+            settingsOpen = false;
+        }
+        if (inRect(mx, my, settBtnX, settBtnY, settBtnW, settBtnH)) {
+            settingsOpen = !settingsOpen;
+            return true;
+        }
+
+        if (inRect(mx, my, basisBtnX, basisBtnY, basisBtnW, basisBtnH)) {
+            basis = (basis == WorthBasis.LBIN) ? WorthBasis.MEDIAN : WorthBasis.LBIN;
+            return true;
+        }
+        if (inRect(mx, my, acceptBtnX, acceptBtnY, acceptBtnW, acceptBtnH)) {
+            // The button renders greyed out while the deal timer is running, so
+            // the click is gated on the same cooldown flag and we just eat it
+            // here rather than forwarding a packet the server would ignore.
+            if (!readTradeState().onCooldown) {
+                forwardSlot(39, 0, ContainerInput.PICKUP);
+            }
+            return true;
+        }
+        if (inRect(mx, my, coinsBtnX, coinsBtnY, coinsBtnW, coinsBtnH)) {
+            Minecraft.getInstance().gui.setScreen(new CoinInputGUI(backing, this));
+            return true;
+        }
+        Integer rowSlot = rowSlotAt(mx, my);
+        if (rowSlot != null) {
+            forwardSlot(rowSlot, button, shift ? ContainerInput.QUICK_MOVE : ContainerInput.PICKUP);
+            return true;
+        }
+        for (int i = 45; i < menu.slots.size(); i++) {
+            int[] rect = invSlotRect(i);
+            if (rect != null && inRect(mx, my, rect[0], rect[1], INV_CELL - 3, INV_CELL - 3)) {
+                forwardSlot(i, button, shift ? ContainerInput.QUICK_MOVE : ContainerInput.PICKUP);
+                return true;
+            }
+        }
+        if (!menu.getCarried().isEmpty()) {
+            int empty = firstEmptyInventorySlot();
+            if (empty >= 0) {
+                forwardSlot(empty, 0, ContainerInput.PICKUP);
+                return true;
+            }
+        }
+        return super.mouseClicked(click, doubled);
+    }
+
+    private int firstEmptyInventorySlot() {
+        for (int i = 45; i < menu.slots.size(); i++) {
+            if (menu.slots.get(i).getItem().isEmpty()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private Integer rowSlotAt(double mx, double my) {
+        if (my < tableTop || my > tableBottom) {
+            return null;
+        }
+        if (mx >= colYouX && mx < colYouX + colW) {
+            return rowSlotInList(buildRows(CoflModClient.TRADE_YOUR_SLOTS), colYouX, scrollYou, mx, my);
+        }
+        if (mx >= colThemX && mx < colThemX + colW) {
+            return rowSlotInList(buildRows(CoflModClient.TRADE_THEIR_SLOTS), colThemX, scrollThem, mx, my);
+        }
+        return null;
+    }
+
+    private Integer rowSlotInList(List<Row> rows, int x, int scroll, double mx, double my) {
+        int cols = cols();
+        int cellW = cellW();
+        int cellH = cellH();
+        for (int idx = 0; idx < rows.size(); idx++) {
+            int col = idx % cols;
+            int line = idx / cols;
+            int cx = x + col * (cellW + 2);
+            int cy = tableTop - scroll + line * cellH;
+            if (inRect(mx, my, cx, cy, cellW, cellH)) {
+                return rows.get(idx).slotId();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double scrollX, double scrollY) {
+        int delta = (int) (-scrollY * cellH());
+        if (mouseX >= colThemX) {
+            scrollThem = clampScroll(scrollThem + delta, buildRows(CoflModClient.TRADE_THEIR_SLOTS).size());
+        } else {
+            scrollYou = clampScroll(scrollYou + delta, buildRows(CoflModClient.TRADE_YOUR_SLOTS).size());
+        }
+        return true;
+    }
+
+    private int clampScroll(int value, int rowCount) {
+        int contentH = contentHeight(rowCount);
+        int viewH = tableBottom - tableTop;
+        int max = Math.max(0, contentH - viewH);
+        return Math.max(0, Math.min(value, max));
+    }
+
+    private void forwardSlot(int slotId, int button, ContainerInput type) {
+        Player player = Minecraft.getInstance().player;
+        if (player == null) {
+            return;
+        }
+        Minecraft.getInstance().gameMode.handleContainerInput(menu.containerId, slotId, button, type, player);
+    }
+
+    private static boolean inRect(double px, double py, int x, int y, int w, int h) {
+        return px >= x && px < x + w && py >= y && py < y + h;
+    }
+
+    private static String ChatStrip(String s) {
+        return net.minecraft.ChatFormatting.stripFormatting(s);
+    }
+
+    private static String truncate(Font font, String text, int maxW) {
+        if (font.width(text) <= maxW) {
+            return text;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (char c : text.toCharArray()) {
+            if (font.width(sb.toString() + c + "..") > maxW) {
+                break;
+            }
+            sb.append(c);
+        }
+        return sb + "..";
+    }
+
+    private static String fmt(long coins) {
+        if (coins >= 1_000_000_000L) {
+            return String.format(java.util.Locale.US, "%.1fB", coins / 1_000_000_000.0);
+        } else if (coins >= 1_000_000L) {
+            return String.format(java.util.Locale.US, "%.1fM", coins / 1_000_000.0);
+        } else if (coins >= 1_000L) {
+            return String.format(java.util.Locale.US, "%.1fK", coins / 1_000.0);
+        }
+        return String.valueOf(coins);
+    }
+
+    private static String fmtFull(long coins) {
+        return String.format(java.util.Locale.US, "%,d", coins);
+    }
+
+    @Override
+    public boolean isPauseScreen() {
+        return false;
+    }
+
+    @Override
+    public void onClose() {
+        backing.onClose();
+        super.onClose();
+    }
+}

--- a/src/client/java/com/coflnet/mixin/ClientPlayerEntityMixin.java
+++ b/src/client/java/com/coflnet/mixin/ClientPlayerEntityMixin.java
@@ -16,6 +16,12 @@ public class ClientPlayerEntityMixin {
     @Inject(method = "openTextEdit", at = @At("HEAD"))
     private void openTextEdit(SignBlockEntity sign, boolean front, CallbackInfo ci){
         try {
+            // Handle trade coins input first (auto-fill the coin amount sign).
+            if (CoflModClient.pendingCoinAmount != null) {
+                handleCoinInput(sign, front);
+                return;
+            }
+
             // Handle bazaar search first
             if (CoflModClient.pendingBazaarSearch != null) {
                 handleBazaarSearch(sign, front);
@@ -42,6 +48,45 @@ public class ClientPlayerEntityMixin {
         } catch (Exception e) {
             System.out.println("[ClientPlayerEntityMixin] openEditSignScreen failed: " + e.getMessage());
         }
+    }
+
+    /**
+     * Handles filling in the trade coin amount and closing the sign. Mirrors the
+     * bazaar-search auto-fill flow exactly — fills line 0 with the digit string
+     * and closes the sign after a short delay so Hypixel registers the amount.
+     */
+    private void handleCoinInput(SignBlockEntity sign, boolean front) {
+        String amount = CoflModClient.pendingCoinAmount;
+        System.out.println("Filling trade coins with: " + amount);
+
+        Component[] lines = sign.getFrontText().getMessages(Minecraft.getInstance().isTextFilteringEnabled());
+        lines[0] = Component.literal(amount);
+        lines[1] = Component.literal("");
+        lines[2] = Component.literal("");
+        lines[3] = Component.literal("");
+
+        sign.updateText(signText -> new SignText(
+                lines, lines,
+                signText.getColor(),
+                signText.hasGlowingText()
+        ), front);
+
+        CoflModClient.pendingCoinAmount = null;
+
+        Minecraft client = Minecraft.getInstance();
+        Thread.startVirtualThread(() -> {
+            try {
+                Thread.sleep(200);
+                client.execute(() -> {
+                    if (client.gui.screen() != null) {
+                        System.out.println("Closing sign screen to complete coin input");
+                        client.gui.screen().onClose();
+                    }
+                });
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
this adds an optional trade overlay for the hypixel trade window, plus the diagnostic and pricing pieces behind it.

what it does

the overlay replaces the trade window when you run cofl tradegui on. it shows two scrollable lists, yours and theirs, split by a thin line. each row has the item icon, the full name, and the worth, with the full name on hover. coins show as a coins row with the full amount. tables are clipped so scrolled rows never bleed over the headers or the buttons. the partner name comes from the trade request chat line, since the window title shortens it.

the inventory sits to the right of the panel at a bigger cell size. a control panel sits to its left with the net profit or loss line, a basis toggle between lbin and median, the accept button, and the other player status. a small settings button cycles the item list between one, two, and three columns, and that choice is saved.

prices come from the backend tip lines. auction items read the lbin and med lines. bazaar items read the buy and sell line and use the per unit each value. coins count at face value, and the coin parser understands k, m, and b suffixes.

the add coins dialog lets you type an amount or pick a suggestion. a lowball slider scales the lbin and med suggestions, and the suggestion subtracts the worth of items you already offered, so the figure is what you still owe. on confirm it fills the real coin sign.

performance

prices refresh only when the trade contents actually change, and the heavy backend call runs off the render thread, so adding or removing an item no longer freezes the client.

dev tools

cofl dev on adds a copy dump button to any container that copies the title, size, and slots to the clipboard. it is independent of the overlay, so you can dump the real trade window for debugging. defaults are off, so nothing changes for users who do not opt in.