### PR TITLE
fix trade pricing and premium access

### DIFF
--- a/src/client/java/com/coflnet/CoflModClient.java
+++ b/src/client/java/com/coflnet/CoflModClient.java
@@ -313,6 +313,7 @@ public class CoflModClient implements ClientModInitializer {
         });
 
         ClientPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
+            com.coflnet.config.TradeGuiManager.clearAccountTier();
             ServerContext detectedServerContext = detectServerContext(null);
             applyServerContext(detectedServerContext);
             lastScoreboardProcessMs = 0L;
@@ -336,6 +337,7 @@ public class CoflModClient implements ClientModInitializer {
         });
 
         ClientPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
+            com.coflnet.config.TradeGuiManager.clearAccountTier();
             applyServerContext(ServerContext.UNKNOWN);
             WSClientWrapper wrapper = CoflCore.Wrapper;
             if (wrapper != null && wrapper.isRunning) {
@@ -424,8 +426,8 @@ public class CoflModClient implements ClientModInitializer {
         // loadDescriptionsForInv gates on, so we trigger the price load directly.
         ScreenEvents.AFTER_INIT.register((client, screen, scaledWidth, scaledHeight) -> {
             if (screen instanceof ContainerScreen cs && isTradeScreenByTitle(cs)) {
-                NonNullList<ItemStack> items = cs.getMenu().getItems();
-                loadDescriptionsForItems(cs.getTitle().getString(), items);
+                com.coflnet.gui.trade.TradePriceCache.clear();
+                com.coflnet.gui.trade.TradePriceCache.request(cs);
 
                 // Replace the trade window with the SkyCofl TradeGUI overlay ONLY
                 // when the trade overlay is enabled (/cofl tradegui on). Dev mode
@@ -768,6 +770,14 @@ public class CoflModClient implements ClientModInitializer {
     /** Worth basis selectable by the user (median vs lowest BIN). */
     public enum WorthBasis { LBIN, MEDIAN }
 
+    // these values are parsed after the existing description request completes.
+    private static final java.util.regex.Pattern LBIN_VALUE = java.util.regex.Pattern.compile(
+            "\\b(?:lbin|lowest\\s*bin)\\s*:?\\s*~?\\s*([\\d,]+(?:\\.\\d+)?(?:\\s*[kmb]\\b)?)",
+            java.util.regex.Pattern.CASE_INSENSITIVE);
+    private static final java.util.regex.Pattern MED_VALUE = java.util.regex.Pattern.compile(
+            "\\bmed(?:ian)?\\s*:?\\s*~?\\s*([\\d,]+(?:\\.\\d+)?(?:\\s*[kmb]\\b)?)",
+            java.util.regex.Pattern.CASE_INSENSITIVE);
+
     /**
      * Extracts a PER-ITEM coin worth from the backend tooltip lines.
      * <p>
@@ -781,7 +791,7 @@ public class CoflModClient implements ClientModInitializer {
         if (tips == null) {
             return null;
         }
-        String prefix = (basis == WorthBasis.LBIN) ? "lbin:" : "med:";
+        java.util.regex.Pattern label = (basis == WorthBasis.LBIN) ? LBIN_VALUE : MED_VALUE;
         Long bazaar = null;
         for (DescriptionHandler.DescModification t : tips) {
             if (t == null || t.value == null) {
@@ -792,15 +802,16 @@ public class CoflModClient implements ClientModInitializer {
                 continue;
             }
             plain = plain.trim();
-            String lower = plain.toLowerCase(Locale.ROOT);
-            // AH line (preferred when present).
-            if (lower.startsWith(prefix)) {
-                Long v = extractFirstNumber(plain);
-                if (v != null) {
+            // prefer the auction value when it is present.
+            java.util.regex.Matcher m = label.matcher(plain);
+            if (m.find()) {
+                Long v = parseCoinNumber(m.group(1));
+                if (v != null && v > 0) {
                     return v;
                 }
             }
             // Bazaar line: "Buy: 37.49K (585.8 each)Sell: 33.38K (521.6 each)".
+            String lower = plain.toLowerCase(Locale.ROOT);
             if (bazaar == null && (lower.contains("buy:") && lower.contains("each"))) {
                 bazaar = parseBazaarEach(plain, basis == WorthBasis.LBIN ? "buy" : "sell");
             }
@@ -818,19 +829,6 @@ public class CoflModClient implements ClientModInitializer {
                 .matcher(plain);
         if (m.find()) {
             return parseCoinNumber(m.group(1));
-        }
-        return null;
-    }
-
-    /** First comma-grouped integer in a string (e.g. "lbin: ~901,098,980 ..." -> 901098980). */
-    private static Long extractFirstNumber(String s) {
-        java.util.regex.Matcher m = java.util.regex.Pattern.compile("(\\d[\\d,]*)").matcher(s);
-        if (m.find()) {
-            try {
-                return Long.parseLong(m.group(1).replace(",", ""));
-            } catch (NumberFormatException e) {
-                return null;
-            }
         }
         return null;
     }

--- a/src/client/java/com/coflnet/EventSubscribers.java
+++ b/src/client/java/com/coflnet/EventSubscribers.java
@@ -4,7 +4,11 @@ import java.util.*;
 
 import CoflCore.classes.*;
 import CoflCore.commands.models.HotkeyRegister;
+import CoflCore.commands.CommandType;
 import CoflCore.events.*;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
@@ -123,7 +127,22 @@ public class EventSubscribers {
 
     @Subscribe
     public void onReceiveCommand(ReceiveCommand event){
-        
+        if (event == null || event.command == null || event.command.getType() == null) {
+            return;
+        }
+        if (event.command.getType() != CommandType.LoggedIn) {
+            return;
+        }
+        try {
+            JsonElement parsed = JsonParser.parseString(event.command.getData());
+            JsonObject data = parsed.isJsonObject() ? parsed.getAsJsonObject() : null;
+            String tier = data != null && data.has("tier") && !data.get("tier").isJsonNull()
+                    ? data.get("tier").getAsString()
+                    : null;
+            com.coflnet.config.TradeGuiManager.setAccountTier(tier);
+        } catch (RuntimeException ignored) {
+            com.coflnet.config.TradeGuiManager.clearAccountTier();
+        }
     }
 
     @Subscribe

--- a/src/client/java/com/coflnet/config/TradeGuiManager.java
+++ b/src/client/java/com/coflnet/config/TradeGuiManager.java
@@ -6,6 +6,8 @@ package com.coflnet.config;
  * controls the Copy Dump diagnostic button).
  */
 public class TradeGuiManager {
+    private static volatile String accountTier = "none";
+
     public static void reloadConfig() {
         CoflModConfig.reload();
     }
@@ -22,6 +24,18 @@ public class TradeGuiManager {
         CoflModConfig cfg = getConfig();
         cfg.tradeGuiEnabled = enabled;
         cfg.save();
+    }
+
+    public static boolean hasPremium() {
+        return accountTier.contains("premium");
+    }
+
+    public static void setAccountTier(String tier) {
+        accountTier = tier == null ? "none" : tier.trim().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    public static void clearAccountTier() {
+        accountTier = "none";
     }
 
     /** Persisted TradeGUI item-list column count, clamped to 1-3. */

--- a/src/client/java/com/coflnet/gui/trade/CoinInputGUI.java
+++ b/src/client/java/com/coflnet/gui/trade/CoinInputGUI.java
@@ -18,9 +18,6 @@ import net.minecraft.world.inventory.ContainerInput;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * Coins input dialog for the trade overlay. Lets the user type any amount
  * (2m, 1.5b, 80000000) OR pick one of two suggestion buttons (their side total
@@ -40,11 +37,11 @@ public class CoinInputGUI extends Screen {
     private final ChestMenu menu;
     private final TradeGUI parent;
 
-    private final long lbinSuggestion;
-    private final long medianSuggestion;
+    private long lbinSuggestion;
+    private long medianSuggestion;
     // Worth of items already on MY side (per basis), subtracted from suggestions.
-    private final long myItemsLbin;
-    private final long myItemsMedian;
+    private long myItemsLbin;
+    private long myItemsMedian;
 
     private EditBox input;
     private int panelX, panelY, panelW, panelH;
@@ -52,29 +49,32 @@ public class CoinInputGUI extends Screen {
     private int confirmX, confirmY, confirmW, confirmH;
     private int cancelX, cancelY, cancelW, cancelH;
 
-    // Lowball slider: 10%–100%, default 70%. The LBIN/Med suggestion buttons
-    // multiply their full total by this percent. This is the SkyCofl premium
-    // lowball overlay — the predecessor (SkyApi) gates it behind premium. We do
-    // NOT enforce that client-side yet, but surface a hint so it's clear it's a
-    // premium feature.
+    // premium access controls the slider and suggestion buttons.
     private int sliderX, sliderY, sliderW, sliderH;
     private int lowballPercent = 70;
     private boolean draggingSlider = false;
     private static final int MIN_PCT = 10;
     private static final int MAX_PCT = 100;
 
+    private static final int LOCKED_TINT = 0xFF3A3F46;
+
     public CoinInputGUI(ContainerScreen backing, TradeGUI parent) {
         super(Component.literal("Coins Input"));
         this.backing = backing;
         this.menu = backing.getMenu();
         this.parent = parent;
-        this.lbinSuggestion = sideTotal(CoflModClient.TRADE_THEIR_SLOTS, WorthBasis.LBIN);
-        this.medianSuggestion = sideTotal(CoflModClient.TRADE_THEIR_SLOTS, WorthBasis.MEDIAN);
-        // Value of items I've ALREADY put on my side (excludes coins — those are
-        // what this dialog adds). Subtracted from the suggestion so e.g. a 4m item
-        // already offered lowers a 32m lowball suggestion to 28m of coins.
-        this.myItemsLbin = sideItemsOnly(CoflModClient.TRADE_YOUR_SLOTS, WorthBasis.LBIN);
-        this.myItemsMedian = sideItemsOnly(CoflModClient.TRADE_YOUR_SLOTS, WorthBasis.MEDIAN);
+        refreshSuggestions();
+    }
+
+    public ContainerScreen getBacking() {
+        return backing;
+    }
+
+    private void refreshSuggestions() {
+        lbinSuggestion = sideTotal(CoflModClient.TRADE_THEIR_SLOTS, WorthBasis.LBIN);
+        medianSuggestion = sideTotal(CoflModClient.TRADE_THEIR_SLOTS, WorthBasis.MEDIAN);
+        myItemsLbin = sideItemsOnly(CoflModClient.TRADE_YOUR_SLOTS, WorthBasis.LBIN);
+        myItemsMedian = sideItemsOnly(CoflModClient.TRADE_YOUR_SLOTS, WorthBasis.MEDIAN);
     }
 
     /** Full-value total of a side for a basis (offered coins count at face value). */
@@ -93,12 +93,7 @@ public class CoinInputGUI extends Screen {
                 total += coins;
                 continue;
             }
-            String id = CoflModClient.getIdFromStack(stack);
-            Long worth = CoflModClient.parseWorthFromTips(
-                    CoflCore.handlers.DescriptionHandler.getTooltipData(id), basis);
-            if (worth != null) {
-                total += worth * stack.getCount();
-            }
+            total += itemWorth(stack, basis);
         }
         return total;
     }
@@ -117,14 +112,14 @@ public class CoinInputGUI extends Screen {
             if (CoflModClient.parseCoinStack(stack) != null) {
                 continue; // skip coins
             }
-            String id = CoflModClient.getIdFromStack(stack);
-            Long worth = CoflModClient.parseWorthFromTips(
-                    CoflCore.handlers.DescriptionHandler.getTooltipData(id), basis);
-            if (worth != null) {
-                total += worth * stack.getCount();
-            }
+            total += itemWorth(stack, basis);
         }
         return total;
+    }
+
+    private long itemWorth(ItemStack stack, WorthBasis basis) {
+        Long worth = TradePriceCache.worth(stack, basis);
+        return worth == null ? 0L : worth * stack.getCount();
     }
 
     @Override
@@ -135,9 +130,10 @@ public class CoinInputGUI extends Screen {
         panelY = this.height / 2 - panelH / 2;
 
         Font font = Minecraft.getInstance().font;
+        String prev = input == null ? "" : input.getValue();
         input = new EditBox(font, panelX + PAD, panelY + 28, panelW - PAD * 2, 16, Component.literal("amount"));
         input.setMaxLength(20);
-        input.setValue("");
+        input.setValue(prev);
         addRenderableWidget(input);
         setInitialFocus(input);
 
@@ -178,20 +174,53 @@ public class CoinInputGUI extends Screen {
 
     @Override
     public void extractBackground(GuiGraphicsExtractor context, int mouseX, int mouseY, float delta) {
+        boolean premium = com.coflnet.config.TradeGuiManager.hasPremium();
+        if (!premium) {
+            draggingSlider = false;
+        }
+        refreshSuggestions();
+
         RenderUtils.drawRoundedRect(context, panelX, panelY, panelW, panelH, RADIUS, CoflColConfig.BACKGROUND_PRIMARY);
         RenderUtils.drawString(context, "§lAdd Coins", panelX + PAD, panelY + PAD, CoflColConfig.TEXT_PRIMARY);
 
-        // Lowball slider. Labelled as a SkyCofl premium feature as the server powered version.
-        RenderUtils.drawString(context, "§7Lowball: §f" + lowballPercent + "% §r§8§o(SkyCofl Premium)", sliderX, sliderY - 10, CoflColConfig.TEXT_PRIMARY);
-        RenderUtils.drawRoundedRect(context, sliderX, sliderY, sliderW, sliderH, 2, CoflColConfig.BACKGROUND_SECONDARY);
-        int knobX = sliderX + (int) ((long) (lowballPercent - MIN_PCT) * (sliderW - 6) / (MAX_PCT - MIN_PCT));
-        RenderUtils.drawRoundedRect(context, knobX, sliderY - 2, 6, sliderH + 4, 2, CoflColConfig.CONFIRM);
+        Font font = Minecraft.getInstance().font;
 
-        // Suggestion buttons (scaled by the lowball percent).
-        drawButton(context, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
-                "LBIN " + fmt(scaled(lbinSuggestion, myItemsLbin)), CoflColConfig.BACKGROUND_SECONDARY, CoflColConfig.CONFIRM_HOVER);
-        drawButton(context, medBtnX, medBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
-                "Med " + fmt(scaled(medianSuggestion, myItemsMedian)), CoflColConfig.BACKGROUND_SECONDARY, CoflColConfig.CONFIRM_HOVER);
+        if (premium) {
+            RenderUtils.drawString(context, "§7lowball: §f" + lowballPercent + "% §r§8§o(skycofl premium)", sliderX, sliderY - 10, CoflColConfig.TEXT_PRIMARY);
+            RenderUtils.drawRoundedRect(context, sliderX, sliderY, sliderW, sliderH, 2, CoflColConfig.BACKGROUND_SECONDARY);
+            int knobX = sliderX + (int) ((long) (lowballPercent - MIN_PCT) * (sliderW - 6) / (MAX_PCT - MIN_PCT));
+            RenderUtils.drawRoundedRect(context, knobX, sliderY - 2, 6, sliderH + 4, 2, CoflColConfig.CONFIRM);
+
+            drawButton(context, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
+                    "lbin " + fmt(scaled(lbinSuggestion, myItemsLbin)), CoflColConfig.BACKGROUND_SECONDARY, CoflColConfig.CONFIRM_HOVER);
+            drawButton(context, medBtnX, medBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
+                    "med " + fmt(scaled(medianSuggestion, myItemsMedian)), CoflColConfig.BACKGROUND_SECONDARY, CoflColConfig.CONFIRM_HOVER);
+
+            RenderUtils.drawString(context, "§8premium suggestions enabled",
+                    panelX + PAD, panelY + 116, CoflColConfig.TEXT_PRIMARY);
+        } else {
+            RenderUtils.drawString(context, "§7lowball: §8locked", sliderX, sliderY - 10, CoflColConfig.TEXT_PRIMARY);
+            RenderUtils.drawRoundedRect(context, sliderX, sliderY, sliderW, sliderH, 2, LOCKED_TINT);
+            drawButton(context, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
+                    "§8lbin locked", LOCKED_TINT, LOCKED_TINT);
+            drawButton(context, medBtnX, medBtnY, sugBtnW, sugBtnH, mouseX, mouseY,
+                    "§8med locked", LOCKED_TINT, LOCKED_TINT);
+            RenderUtils.drawString(context, "§8premium suggestions locked",
+                    panelX + PAD, panelY + 116, CoflColConfig.TEXT_PRIMARY);
+
+            boolean overLocked = inRect(mouseX, mouseY, sliderX, sliderY - 12, sliderW, sliderH + 14)
+                    || inRect(mouseX, mouseY, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH)
+                    || inRect(mouseX, mouseY, medBtnX, medBtnY, sugBtnW, sugBtnH);
+            if (overLocked) {
+                context.setComponentTooltipForNextFrame(font, java.util.List.of(
+                        Component.literal("§6requires skycofl premium"),
+                        Component.literal("§7suggests lowball prices for you, adjustable"),
+                        Component.literal("§7with the lowball slider and lbin or med buttons."),
+                        Component.literal("§7get it with §e/cofl buy premium§7."),
+                        Component.literal("§8premium access is read from login.")),
+                        mouseX, mouseY);
+            }
+        }
 
         // Confirm / cancel.
         drawButton(context, confirmX, confirmY, confirmW, confirmH, mouseX, mouseY,
@@ -212,18 +241,32 @@ public class CoinInputGUI extends Screen {
         double mx = click.x();
         double my = click.y();
 
+        boolean premium = com.coflnet.config.TradeGuiManager.hasPremium();
+
         // Slider grab (generous vertical hit area).
         if (inRect(mx, my, sliderX, sliderY - 4, sliderW, sliderH + 8)) {
-            draggingSlider = true;
-            updateSlider(mx);
+            if (premium) {
+                draggingSlider = true;
+                updateSlider(mx);
+            }
             return true;
         }
         if (inRect(mx, my, lbinBtnX, lbinBtnY, sugBtnW, sugBtnH)) {
-            input.setValue(String.valueOf(scaled(lbinSuggestion, myItemsLbin)));
+            if (premium) {
+                long value = scaled(lbinSuggestion, myItemsLbin);
+                if (value > 0L) {
+                    input.setValue(String.valueOf(value));
+                }
+            }
             return true;
         }
         if (inRect(mx, my, medBtnX, medBtnY, sugBtnW, sugBtnH)) {
-            input.setValue(String.valueOf(scaled(medianSuggestion, myItemsMedian)));
+            if (premium) {
+                long value = scaled(medianSuggestion, myItemsMedian);
+                if (value > 0L) {
+                    input.setValue(String.valueOf(value));
+                }
+            }
             return true;
         }
         if (inRect(mx, my, confirmX, confirmY, confirmW, confirmH)) {

--- a/src/client/java/com/coflnet/gui/trade/TradeGUI.java
+++ b/src/client/java/com/coflnet/gui/trade/TradeGUI.java
@@ -10,7 +10,6 @@ import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.ContainerScreen;
 import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.ChestMenu;
@@ -74,12 +73,6 @@ public class TradeGUI extends Screen {
     private int scrollYou = 0;
     private int scrollThem = 0;
 
-    // Lag fix: instead of polling the heavy backend pipeline every second from
-    // the render thread, we detect changes with a CHEAP signature of just the
-    // trade slots and only re-price OFF-thread when that signature changes.
-    private String lastTradeSig = null;
-    private volatile boolean repriceInFlight = false;
-
     private record Row(int slotId, ItemStack stack, boolean isCoins, long coinAmount) {}
 
     public TradeGUI(ContainerScreen backing) {
@@ -87,6 +80,10 @@ public class TradeGUI extends Screen {
         this.backing = backing;
         this.menu = backing.getMenu();
         this.otherName = resolveOtherName(backing.getTitle().getString());
+    }
+
+    public ContainerScreen getBacking() {
+        return backing;
     }
 
     /**
@@ -111,58 +108,6 @@ public class TradeGUI extends Screen {
         }
         t = t.trim();
         return t.isEmpty() ? "THEM" : t;
-    }
-
-    /**
-     * Cheap per-frame change detection over just the trade slots (both sides).
-     * Builds a tiny string of itemId×count per non-empty trade slot — no NBT,
-     * no gzip, no base64. Only when this signature changes do we fire the heavy
-     * backend re-price, and we do it on a virtual thread so the render thread
-     * never blocks (root cause of the add/remove FPS spikes).
-     */
-    private void maybeReprice() {
-        StringBuilder sig = new StringBuilder();
-        appendSig(sig, CoflModClient.TRADE_YOUR_SLOTS);
-        appendSig(sig, CoflModClient.TRADE_THEIR_SLOTS);
-        String current = sig.toString();
-        if (current.equals(lastTradeSig)) {
-            return;
-        }
-        // Check the in flight flag before we advance lastTradeSig, so a change
-        // that lands while a reprice is running is not swallowed. We leave
-        // lastTradeSig on the old value and just bail, and then the next frame
-        // still sees a mismatch and fires the reprice once the slot is free.
-        if (repriceInFlight) {
-            return;
-        }
-        lastTradeSig = current;
-        repriceInFlight = true;
-        final String title = backing.getTitle().getString();
-        final NonNullList<ItemStack> snapshot = NonNullList.create();
-        snapshot.addAll(menu.getItems());
-        Thread.startVirtualThread(() -> {
-            try {
-                CoflModClient.loadDescriptionsForItems(title, snapshot);
-            } catch (Exception ignored) {
-            } finally {
-                repriceInFlight = false;
-            }
-        });
-    }
-
-    private void appendSig(StringBuilder sig, int[] slots) {
-        for (int slot : slots) {
-            if (slot >= menu.slots.size()) {
-                continue;
-            }
-            ItemStack stack = menu.slots.get(slot).getItem();
-            if (stack.isEmpty()) {
-                continue;
-            }
-            sig.append(slot).append(':')
-               .append(CoflModClient.getIdFromStack(stack)).append('x')
-               .append(stack.getCount()).append(';');
-        }
     }
 
     @Override
@@ -273,9 +218,7 @@ public class TradeGUI extends Screen {
         if (row.isCoins()) {
             return row.coinAmount();
         }
-        String id = CoflModClient.getIdFromStack(row.stack());
-        Long w = CoflModClient.parseWorthFromTips(
-                CoflCore.handlers.DescriptionHandler.getTooltipData(id), basis);
+        Long w = TradePriceCache.worth(row.stack(), basis);
         return (w == null ? 0L : w) * row.stack().getCount();
     }
 
@@ -294,12 +237,6 @@ public class TradeGUI extends Screen {
             return;
         }
         Font font = Minecraft.getInstance().font;
-
-        // Re-price ONLY when the trade contents actually change, and do the heavy
-        // backend call OFF the render thread. The old code serialized all 45 slots
-        // to NBT+gzip+base64 and hit the backend synchronously every second on the
-        // render thread → multi-second FPS-to-0 spikes on every add/remove.
-        maybeReprice();
 
         List<Row> youRows = buildRows(CoflModClient.TRADE_YOUR_SLOTS);
         List<Row> themRows = buildRows(CoflModClient.TRADE_THEIR_SLOTS);

--- a/src/client/java/com/coflnet/gui/trade/TradePriceCache.java
+++ b/src/client/java/com/coflnet/gui/trade/TradePriceCache.java
@@ -1,0 +1,156 @@
+package com.coflnet.gui.trade;
+
+import CoflCore.handlers.DescriptionHandler;
+import com.coflnet.CoflModClient;
+import com.coflnet.CoflModClient.WorthBasis;
+import net.minecraft.client.gui.screens.inventory.ContainerScreen;
+import net.minecraft.core.NonNullList;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+public final class TradePriceCache {
+    private static final AtomicLong generation = new AtomicLong();
+    private static final AtomicLong requestSequence = new AtomicLong();
+    private static final AtomicBoolean workerRunning = new AtomicBoolean();
+    private static final AtomicReference<Request> queued = new AtomicReference<>();
+    private static volatile Map<String, Prices> prices = Map.of();
+    private static volatile List<ItemStack> tradeItems = List.of();
+
+    private TradePriceCache() {
+    }
+
+    public static void clear() {
+        generation.incrementAndGet();
+        requestSequence.incrementAndGet();
+        queued.set(null);
+        prices = Map.of();
+        tradeItems = List.of();
+    }
+
+    public static void request(ContainerScreen screen) {
+        if (screen == null || !CoflModClient.isTradeScreenByTitle(screen)) {
+            return;
+        }
+        NonNullList<ItemStack> snapshot = NonNullList.create();
+        for (ItemStack stack : screen.getMenu().getItems()) {
+            snapshot.add(stack.copy());
+        }
+        List<ItemStack> currentTradeItems = tradeItems(snapshot);
+        if (!sameItems(currentTradeItems, tradeItems)) {
+            tradeItems = currentTradeItems;
+            prices = Map.of();
+        }
+        long sequence = requestSequence.incrementAndGet();
+        queued.set(new Request(screen.getTitle().getString(), snapshot, generation.get(), sequence));
+        drain();
+    }
+
+    public static Long worth(ItemStack stack, WorthBasis basis) {
+        if (stack == null || stack.isEmpty()) {
+            return null;
+        }
+        Prices value = prices.get(CoflModClient.getIdFromStack(stack));
+        if (value == null) {
+            return null;
+        }
+        long worth = basis == WorthBasis.LBIN ? value.lbin : value.median;
+        return worth > 0L ? worth : null;
+    }
+
+    private static void drain() {
+        if (!workerRunning.compareAndSet(false, true)) {
+            return;
+        }
+        Thread.startVirtualThread(() -> {
+            try {
+                Request request;
+                while ((request = queued.getAndSet(null)) != null) {
+                    load(request);
+                }
+            } finally {
+                workerRunning.set(false);
+                if (queued.get() != null) {
+                    drain();
+                }
+            }
+        });
+    }
+
+    private static void load(Request request) {
+        try {
+            CoflModClient.loadDescriptionsForItems(request.title, request.items);
+            if (!isCurrent(request)) {
+                return;
+            }
+            Map<String, Prices> updated = new HashMap<>();
+            for (ItemStack stack : request.items) {
+                if (stack.isEmpty()) {
+                    continue;
+                }
+                String id = CoflModClient.getIdFromStack(stack);
+                DescriptionHandler.DescModification[] tips = DescriptionHandler.getTooltipData(id);
+                Long lbin = CoflModClient.parseWorthFromTips(tips, WorthBasis.LBIN);
+                Long median = CoflModClient.parseWorthFromTips(tips, WorthBasis.MEDIAN);
+                if (lbin != null || median != null) {
+                    updated.put(id, new Prices(value(lbin), value(median)));
+                }
+            }
+            if (isCurrent(request)) {
+                prices = Map.copyOf(updated);
+            }
+        } catch (Throwable throwable) {
+            System.out.println("[trade] description refresh failed, " + throwable);
+        }
+    }
+
+    private static long value(Long value) {
+        return value == null ? 0L : value;
+    }
+
+    private static boolean isCurrent(Request request) {
+        return request.generation == generation.get() && request.sequence == requestSequence.get();
+    }
+
+    private static List<ItemStack> tradeItems(NonNullList<ItemStack> items) {
+        List<ItemStack> result = new ArrayList<>(
+                CoflModClient.TRADE_YOUR_SLOTS.length + CoflModClient.TRADE_THEIR_SLOTS.length);
+        appendSlots(result, items, CoflModClient.TRADE_YOUR_SLOTS);
+        appendSlots(result, items, CoflModClient.TRADE_THEIR_SLOTS);
+        return List.copyOf(result);
+    }
+
+    private static void appendSlots(List<ItemStack> result, NonNullList<ItemStack> items, int[] slots) {
+        for (int slot : slots) {
+            if (slot < items.size()) {
+                result.add(items.get(slot).copy());
+            } else {
+                result.add(ItemStack.EMPTY);
+            }
+        }
+    }
+
+    private static boolean sameItems(List<ItemStack> first, List<ItemStack> second) {
+        if (first.size() != second.size()) {
+            return false;
+        }
+        for (int i = 0; i < first.size(); i++) {
+            if (!ItemStack.matches(first.get(i), second.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private record Request(String title, NonNullList<ItemStack> items, long generation, long sequence) {
+    }
+
+    private record Prices(long lbin, long median) {
+    }
+}

--- a/src/client/java/com/coflnet/mixin/NewItemInChestMixin.java
+++ b/src/client/java/com/coflnet/mixin/NewItemInChestMixin.java
@@ -59,9 +59,19 @@ public class NewItemInChestMixin {
     private void onPacketReceive(ClientboundContainerSetSlotPacket packet, CallbackInfo ci) {
         try {
             String itemTitle = packet.getItem().getCustomName() != null ? packet.getItem().getCustomName().getString() : "";
-            if (!itemTitle.isEmpty() && (
-                    itemTitle.contains("Pending their confirm") || itemTitle.contains("Deal timer!") // trade window
-                    || itemTitle.contains("Combine Items") // anvil result
+            boolean tradeUpdate = itemTitle.contains("Pending their confirm") || itemTitle.contains("Deal timer!");
+            if (tradeUpdate) {
+                var screen = Minecraft.getInstance().gui.screen();
+                if (screen instanceof com.coflnet.gui.trade.TradeGUI trade) {
+                    com.coflnet.gui.trade.TradePriceCache.request(trade.getBacking());
+                } else if (screen instanceof com.coflnet.gui.trade.CoinInputGUI coins) {
+                    com.coflnet.gui.trade.TradePriceCache.request(coins.getBacking());
+                } else if (screen instanceof net.minecraft.client.gui.screens.inventory.ContainerScreen container
+                        && CoflModClient.isTradeScreenByTitle(container)) {
+                    com.coflnet.gui.trade.TradePriceCache.request(container);
+                }
+            } else if (!itemTitle.isEmpty() && (
+                    itemTitle.contains("Combine Items") // anvil result
                     || itemTitle.equals("§aFlip Order") // bazaar order flip prices loaded
             || itemTitle.contains("AUCTION FOR") // putting item in auction create
             )) {


### PR DESCRIPTION
this pull request addresses the requested trade review changes.

premium access now comes from the raw `loggedIn` tier field. no chat or tooltip text is parsed to decide access.

trade prices reuse the existing description loading request and the existing trade slot packet listener. pricing work runs away from the render thread. copied item snapshots are matched with exact stack contents before cached prices are displayed.

`TradeWorth` and `LowballHelper` were removed. generic donutsmp logic matches main.

the movable flip hud is isolated in pull request 72.

verification completed with `./gradlew clean build --no-daemon`.